### PR TITLE
✨ Feat: 작성 페이지 내 텍스트 atom 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,15 @@
 import GlobalStyles from './styles/GlobalStyles'
 import DateInput from './components/atoms/DateInput'
+import WriteTitle from './components/atoms/Title/WriteTitle'
+import WriteSubtitle from './components/atoms/Title/WriteSubtitle'
 
 function App() {
   return (
     <div className="App">
       <GlobalStyles />
       <DateInput />
+      <WriteTitle />
+      <WriteSubtitle />
     </div>
   )
 }

--- a/src/components/atoms/Title/WriteSubtitle.jsx
+++ b/src/components/atoms/Title/WriteSubtitle.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { styled } from 'styled-components'
+
+export default function WriteSubtitle({ subtitle }) {
+  return <Title>{subtitle}</Title>
+}
+
+WriteSubtitle.defaultProps = {
+  subtitle: '서브타이틀',
+}
+
+// style
+const Title = styled.h4`
+  color: var(--font-color);
+  font-size: 20px;
+`

--- a/src/components/atoms/Title/WriteTitle.jsx
+++ b/src/components/atoms/Title/WriteTitle.jsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { styled } from 'styled-components'
+
+export default function WriteTitle({ title, description }) {
+  return (
+    <Wrap>
+      <Title>{title}</Title>
+      <Description>{description}</Description>
+    </Wrap>
+  )
+}
+
+WriteTitle.defaultProps = {
+  title: '타이틀',
+  description: '타이틀 설명',
+}
+
+// style
+const Wrap = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+`
+
+const Title = styled.h2`
+  color: var(--font-color);
+  font-size: 32px;
+`
+const Description = styled.p`
+  color: var(--gray-color);
+  font-size: 14px;
+`


### PR DESCRIPTION
# 📝 PR: 작성 페이지 내 텍스트 atom 구현

## Summary
Write 페이지 내 타이틀 항목과 관련된 텍스트 atoms  생성

## Description
- `WriteTitle`: 프로필, 프로젝트, 자격증과 같은 항목 별 **메인 타이틀**과 타이틀에 대한 **설명 문구**
- `WriteSubtitle`: 기술 스택, GitHub과 같이 메인 타이틀 하위에 들어가는 **서브타이틀**
- 📌 참고 사항 1: 작성 페이지와 미리 보기 페이지 내 컴포넌트명 중복 방지를 위해 경현님과 컴포넌트 앞에 Write-, Preview-로 구분하는 것으로 논의되었습니다.
- 📌 참고 사항 2: `WriteTitle` 컴포넌트의 경우 초반에 타이틀과 설명 파트로 분리해 작업했으나 항상 같이 사용되는 부분이라 한 컴포넌트로 통합해 작업했습니다.

