### PR TITLE
:sparkles: Feat: dropBox atom 구현

### DIFF
--- a/src/components/atoms/DropBox/DropBox.jsx
+++ b/src/components/atoms/DropBox/DropBox.jsx
@@ -10,7 +10,6 @@ export default function DropBox({
   setIsSelected,
   selectedData,
   setSelectedData,
-  buttonOnClick,
 }) {
   // 아래 코드를 부모 컴포넌트에서 작성할 수 있도록
   //   const [selectedData, setSelectedData] = useState(
@@ -25,7 +24,6 @@ export default function DropBox({
   //     setIsSelected={setIsSelected}
   //     selectedData={selectedData}
   //     setSelectedData={setSelectedData}
-  //     buttonOnClick={handleClickBtn}
   //   />
 
   // 드롭박스 외부 클릭했을 시 닫기
@@ -43,13 +41,21 @@ export default function DropBox({
   return (
     <DropBoxCont width={width} ref={dropBoxRef}>
       {!isSelected ? (
-        <DropBtn onClick={buttonOnClick}>
+        <DropBtn
+          onClick={() => {
+            setIsSelected((isSelected) => !isSelected)
+          }}
+        >
           {selectedData}
           <img src={TriangleDown} />
         </DropBtn>
       ) : (
         <>
-          <DropBtn onClick={buttonOnClick}>
+          <DropBtn
+            onClick={() => {
+              setIsSelected((isSelected) => !isSelected)
+            }}
+          >
             {selectedData}
             <img src={TriangleUp} />
           </DropBtn>


### PR DESCRIPTION
## Summary

- dropBox atom 구현

## Description

부모 컴포넌트에서 DropBox 사용예시
```js
    const [selectedData, setSelectedData] = useState(
      previousData ? previousData : placeHolder
    )

    <DropBox
      width={131}
      list={['naver.com', 'daum.net', 'gmail.com']}
      isSelected={isSelected}
      setIsSelected={setIsSelected}
      selectedData={selectedData}
      setSelectedData={setSelectedData}
    />
```
- previousData의 존재 여부에 따라 default값 설정
- width 값으로 메일드롭박스, 경력드롭박스 너비 지정
- list로 드롭박스에 들어갈 data 전달
- [isSelected, setIsSelected] 전달하여 드롭박스 오픈 여부 확인 및 설정
- [selectedData, setSelectedData]로 선택된 데이터 설정