### PR TITLE
#32 - Fix: ColorPicker 레이아웃 수정

### DIFF
--- a/src/components/organisms/ColorPicker/ColorPicker.jsx
+++ b/src/components/organisms/ColorPicker/ColorPicker.jsx
@@ -106,7 +106,7 @@ const ColorPickerBtn = styled.button`
 
 const PickBox = styled.div`
   position: absolute;
-  right: -260px;
+  left: calc(100% + 20px);
   background-color: #fff;
   border-radius: 16px;
 `


### PR DESCRIPTION
# 📝 PR: Fix: ColorPicker 레이아웃 수정

## Summary
`ColorPickerBtn`을 눌렀을 때 `NavBar`가 밀려나는 현상 수정

## Description
### Issue
 `ColorPickerCont`와 `PickBox` 가 flex-items로 나란히 있는 상태 => `PickBox`가 나왔을 때 해당 요소의 높이 만큼 하단의 `NavBar`가 밀려나는 현상
![image](https://github.com/weniv/MAKE-RE_ver2/assets/80025366/0563ce02-7e7a-4e38-b024-c2b08b809634)
### Solution
`PickBox`에 `position: absolute` 추가 => `NavBar`가 영향 받지 않는 고정 위치 설정
 
close #32 
