### PR TITLE
✨ Feat: WritePage 재렌더링시에도 작성중이던 페이지와 nav list 유지하도록 수정

### DIFF
--- a/src/components/atoms/Nav/NavList.jsx
+++ b/src/components/atoms/Nav/NavList.jsx
@@ -10,13 +10,11 @@ export default function NavList({
   clickIdx,
   listName,
   id,
-  idx,
   isFill,
   type,
   onClick,
 }) {
   const { mainColor, upadteMainColor } = useContext(ColorContext)
-  // const [clicked, setClickIdx] = useState(clickIdx === idx)
   const [clicked, setClickIdx] = useState(clickIdx === id)
 
   if (useContext(dndContext)) {
@@ -27,7 +25,7 @@ export default function NavList({
   }
 
   useEffect(() => {
-    if (clickIdx === idx) {
+    if (clickIdx === id) {
       setClickIdx(true)
     } else {
       setClickIdx(false)

--- a/src/components/organisms/Nav/NavBar.jsx
+++ b/src/components/organisms/Nav/NavBar.jsx
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components'
 import NavList from '../../atoms/Nav/NavList'
-import { useContext, useState } from 'react'
+import { useContext, useState, useRef, useEffect } from 'react'
 import { remoteList } from '../../../data/dummy'
 import { Dnd } from '../../../utils'
 import RemoteContext from '../../../context/RemoteContext'
@@ -14,7 +14,11 @@ export default function NavBar({ type }) {
 
   const handleClickList = (item, idx) => {
     setClickIdx(idx)
-    updateCurrentSection(item.title)
+    const val = {
+      id: item.id,
+      title: item.title,
+    }
+    updateCurrentSection(val)
   }
 
   return (
@@ -23,7 +27,7 @@ export default function NavBar({ type }) {
         {list.map((item, idx) => {
           return (
             <NavList
-              clickIdx={clickIdx}
+              clickIdx={JSON.parse(localStorage.getItem('section')).id}
               listName={item.title}
               idx={idx}
               key={item.id}

--- a/src/context/RemoteContext.jsx
+++ b/src/context/RemoteContext.jsx
@@ -4,16 +4,16 @@ const RemoteContext = React.createContext()
 
 export const RemoteProvider = ({ children }) => {
   const curSection = localStorage.getItem('section')
-  const [currentSection, setCurrentSection] = useState(
-    curSection ? curSection : '프로필'
-  )
 
+  const [currentSection, setCurrentSection] = useState(
+    curSection ? JSON.parse(curSection) : { id: 1, title: '프로필' }
+  )
   const updateCurrentSection = (section) => {
     setCurrentSection(section)
   }
 
   useEffect(() => {
-    localStorage.setItem('section', currentSection)
+    localStorage.setItem('section', JSON.stringify(currentSection))
   }, [currentSection])
 
   return (

--- a/src/pages/WritePage.jsx
+++ b/src/pages/WritePage.jsx
@@ -12,13 +12,11 @@ import Education from '../components/templates/Education/Education'
 import { CareerTemplate } from '../components/templates/Career'
 import { ProjectTemplate } from '../components/templates/Project'
 import RemoteContext from '../context/RemoteContext'
-import { GithubApi } from '../api'
 import { ResumeContext } from '../context/ResumeContext'
-import reset from 'styled-reset'
 
 export default function WritePage() {
-  const { currentSection, updateCurrentSection } = useContext(RemoteContext)
-  const { resumeData, setResumeData } = useContext(ResumeContext)
+  const { currentSection } = useContext(RemoteContext)
+  const { setResumeData } = useContext(ResumeContext)
   const components = {
     프로필: Profile,
     자기소개서: Intro,
@@ -30,7 +28,7 @@ export default function WritePage() {
     '추가 URL': Url,
   }
 
-  const CurrentComponent = components[currentSection]
+  const CurrentComponent = components[currentSection.title]
 
   useEffect(() => {
     const data = JSON.parse(localStorage.getItem('resumeData'))


### PR DESCRIPTION
# 📝 PR: WritePage 재렌더링시에도 작성중이던 페이지와 nav list 유지하도록 수정

## Summary
- 작성중인 페이지 정보와 list id를 localStorage에 저장하여 재렌더링시에도 작성중이던 페이지와 nav list를 유지하도록 변경