### PR TITLE
:memo: PR: 로컬 스토리지에 데이터가 없는 경우 프로필 section 출력

### DIFF
--- a/src/components/organisms/Nav/NavBar.jsx
+++ b/src/components/organisms/Nav/NavBar.jsx
@@ -6,14 +6,12 @@ import { Dnd } from '../../../utils'
 import RemoteContext from '../../../context/RemoteContext'
 
 export default function NavBar({ type }) {
-  const [clickIdx, setClickIdx] = useState(0)
   const [isFill, setIsFill] = useState(false)
   const [list, setList] = useState(remoteList)
 
-  const { updateCurrentSection } = useContext(RemoteContext)
+  const { currentSection, updateCurrentSection } = useContext(RemoteContext)
 
   const handleClickList = (item, idx) => {
-    setClickIdx(idx)
     const val = {
       id: item.id,
       title: item.title,
@@ -27,7 +25,7 @@ export default function NavBar({ type }) {
         {list.map((item, idx) => {
           return (
             <NavList
-              clickIdx={JSON.parse(localStorage.getItem('section')).id}
+              clickIdx={currentSection.id}
               listName={item.title}
               idx={idx}
               key={item.id}

--- a/src/context/RemoteContext.jsx
+++ b/src/context/RemoteContext.jsx
@@ -14,6 +14,7 @@ export const RemoteProvider = ({ children }) => {
 
   useEffect(() => {
     localStorage.setItem('section', JSON.stringify(currentSection))
+    console.log('set', currentSection)
   }, [currentSection])
 
   return (


### PR DESCRIPTION
## Summary
- section 데이터 출력 오류 해결

## Description
### 문제 상황
- `component/organisms/Component/Nav/NavBar.jsx`
- props로 localstorage에 있는 데이터를 전달할 때, localstorage가 비어있는 경우 오류가 발생합니다.

### 해결
- localstorage 데이터를 가져오는 처리는 `context/RemoteContext.jsx` 에서 진행
- `NavBar.jsx`에서는 context API를 이용하여, 로컬스토리지로 가져온 데이터를 사용
- 아래와 같이, Context API 선언부에서 데이터 초기 설정 진행
```jsx
//context/Remotecontext.jsx
  const [currentSection, setCurrentSection] = useState(
    curSection ? JSON.parse(curSection) : { id: 1, title: '프로필' }
  )
```

## Checklist
- [ ] 로컬 스토리지 삭제 후 접속 시, 기본 페이지(1-프로필) 화면 출력
- [ ] 섹션 변경 시, 로컬 스토리지 갱신 여부
- [ ] 섹션 변경 후, 새로고침 시 마지막에 선택한 섹션 출력