### PR TITLE
:bug: Fix: ProfileImg 변경 시 데이터 구조 변경 오류 해결

### DIFF
--- a/src/components/templates/Profile/Profile.jsx
+++ b/src/components/templates/Profile/Profile.jsx
@@ -32,6 +32,7 @@ export default function Profile() {
   }, [])
 
   useEffect(() => {
+    console.log('profileData', profileData)
     setResumeData({ ...resumeData, profile: profileData })
   }, [profileData])
 
@@ -143,7 +144,7 @@ export default function Profile() {
                 type="file"
                 accept="image/*"
                 id="profile-upload"
-                onChange={(e) => uploadImg(e, resumeData, setProfileData)}
+                onChange={(e) => uploadImg(e, profileData, setProfileData)}
               />
             </styles.ImgCont>
 


### PR DESCRIPTION
## Summary
- 프로필 이미지 변경 시, 데이터 구조 오류 수정

## Description
### 문제상황
- 프로필 이미지 변경 시, resumeData['profile']이 resumeData 객체로 갱신되는 오류 발생
- 데이터 구조의 변경으로 원하는 데이터 불러오기 실패

### 해결
- 프로필 이미지 업데이트 핸들러인 uploadImg에 기존 데이터를 profileData로 변경
- resumeData['profile']이 profileData를 이용하여 데이터 갱신

close #87

## Checklist

- [x] 이미지 변경 후, resumeData 구조 확인 (로컬 스토리지)
- [x] 이미지 삭제 후, resumeData 구조 확인 (로컬 스토리지)