### PR TITLE
✨ Feat: ColorPicker 테마 변경

### DIFF
--- a/src/components/organisms/ColorPicker/ColorPicker.jsx
+++ b/src/components/organisms/ColorPicker/ColorPicker.jsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useState, useRef } from 'react'
 import styled, { css } from 'styled-components'
-import { SketchPicker } from 'react-color'
+import { BlockPicker } from 'react-color'
 import ColorPalette from '../../atoms/Nav/ColorPalette'
 import ColorContext from '../../../context/ColorContext'
 
@@ -121,11 +121,15 @@ const PickBox = styled.div`
   left: calc(100% + 20px);
   background-color: #fff;
   border-radius: 16px;
+
+  .block-picker > div:first-child {
+    transform: rotate(-90deg) !important;
+    top: 30px !important;
+    left: -4px !important;
+  }
 `
 
-const Picker = styled(SketchPicker)`
+const Picker = styled(BlockPicker)`
   border-radius: 16px !important;
   box-shadow: none !important;
-  background-color: var(--bg-color) !important;
-  padding: 20px !important;
 `


### PR DESCRIPTION
# 📝 PR: ColorPicker 테마 변경

## Summary
ColorPicker 테마 변경

## Description
- 테마 변경 (Sketch -> Block)
- 화살표 스타일 커스텀
![image](https://github.com/weniv/MAKE-RE_ver2/assets/80025366/a8f24890-ff39-4460-9f35-c9f287c56b41)


## Checklist

- [x] 테마 및 스타일 변경
- [x] ColorPicker 컨텍스트 적용 확인

close #33 