### PR TITLE
📝 PR: 출력 페이지 URL 컴포넌트 구현

### DIFF
--- a/src/components/atoms/ColorIcon/ColorIcon.jsx
+++ b/src/components/atoms/ColorIcon/ColorIcon.jsx
@@ -1,0 +1,28 @@
+import React, { useContext } from 'react'
+import styled from 'styled-components'
+import ColorContext from '../../../context/ColorContext'
+
+export default function ColorIcon({ iconPath }) {
+  const { mainColor } = useContext(ColorContext)
+
+  return (
+    <>
+      <Icon color={mainColor} iconPath={iconPath} />
+    </>
+  )
+}
+
+const Icon = styled.div`
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background-color: ${(props) => props.color};
+  mask-image: url(${(props) => props.iconPath});
+  mask-size: 100%;
+  mask-repeat: no-repeat;
+  mask-position: center center;
+  -webkit-mask-image: url(${(props) => props.iconPath});
+  -webkit-mask-size: 100%;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center center;
+`

--- a/src/components/atoms/PreviewItem/PreviewLink.jsx
+++ b/src/components/atoms/PreviewItem/PreviewLink.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import styled from 'styled-components'
+
+export default function PreviewLink({ link }) {
+  function urlFormat(url) {
+    // url 절대경로 변환
+    if (!url.startsWith('https://') && !url.startsWith('http://')) {
+      url = 'http://' + url
+    }
+    return url
+  }
+  return <LinkItem href={urlFormat(link)}>{link}</LinkItem>
+}
+
+const LinkItem = styled.a`
+  display: inline-block;
+  background-color: #f2f2f2;
+  padding: 8px 12px;
+  color: inherit;
+  text-decoration: none;
+  border-radius: 5px;
+`

--- a/src/components/atoms/PreviewItem/PreviewLink.jsx
+++ b/src/components/atoms/PreviewItem/PreviewLink.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
+import ColorIcon from '../ColorIcon/ColorIcon'
+import IconUrl from '../../../assets/icon-Url.svg'
 
 export default function PreviewLink({ link }) {
   function urlFormat(url) {
@@ -9,14 +11,31 @@ export default function PreviewLink({ link }) {
     }
     return url
   }
-  return <LinkItem href={urlFormat(link)}>{link}</LinkItem>
+  return (
+    <LinkContainer>
+      <ColorIcon iconPath={IconUrl} />
+      <LinkItem href={urlFormat(link)} target="_blank">
+        {link}
+      </LinkItem>
+    </LinkContainer>
+  )
 }
 
 const LinkItem = styled.a`
-  display: inline-block;
-  background-color: #f2f2f2;
-  padding: 8px 12px;
   color: inherit;
   text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`
+
+const LinkContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 8px 12px;
+  background-color: #f2f2f2;
   border-radius: 5px;
 `

--- a/src/components/templates/Url/Url.jsx
+++ b/src/components/templates/Url/Url.jsx
@@ -25,7 +25,7 @@ export default function Url() {
 
   const val = {
     id: nextId.current,
-    title: '',
+    content: '',
     link: '',
   }
 

--- a/src/components/templates/Url/UrlPreview.jsx
+++ b/src/components/templates/Url/UrlPreview.jsx
@@ -1,0 +1,27 @@
+import React, { useContext } from 'react'
+import { LocalContext } from '../../../pages/PreviewPage'
+import ColorContext from '../../../context/ColorContext'
+import { PreviewSubtitle } from '../../atoms/Title'
+import PreviewLink from '../../atoms/PreviewItem/PreviewLink'
+
+export default function EducationPreview() {
+  const { data } = useContext(LocalContext)
+  const urlData = data.url
+  const urlList = urlData.filter((url) => url.content.trim() || url.link.trim())
+
+  return (
+    <>
+      {!!urlList.length && (
+        <section>
+          <PreviewSubtitle>Url</PreviewSubtitle>
+          {urlList.map((url) => (
+            <div>
+              <p>{url.content}</p>
+              <PreviewLink link={url.link} />
+            </div>
+          ))}
+        </section>
+      )}
+    </>
+  )
+}

--- a/src/components/templates/Url/UrlPreview.jsx
+++ b/src/components/templates/Url/UrlPreview.jsx
@@ -1,8 +1,8 @@
 import React, { useContext } from 'react'
 import { LocalContext } from '../../../pages/PreviewPage'
-import ColorContext from '../../../context/ColorContext'
 import { PreviewSubtitle } from '../../atoms/Title'
 import PreviewLink from '../../atoms/PreviewItem/PreviewLink'
+import styled from 'styled-components'
 
 export default function EducationPreview() {
   const { data } = useContext(LocalContext)
@@ -14,14 +14,33 @@ export default function EducationPreview() {
       {!!urlList.length && (
         <section>
           <PreviewSubtitle>Url</PreviewSubtitle>
-          {urlList.map((url) => (
-            <div>
-              <p>{url.content}</p>
-              <PreviewLink link={url.link} />
-            </div>
-          ))}
+          <UrlListContainer>
+            {urlList.map((url) => (
+              <li>
+                <UrlContent>{url.content}</UrlContent>
+                <PreviewLink link={url.link} />
+              </li>
+            ))}
+          </UrlListContainer>
         </section>
       )}
     </>
   )
 }
+
+const UrlListContainer = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+
+  & li {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+`
+
+const UrlContent = styled.p`
+  font-size: 16px;
+  font-weight: 700;
+`

--- a/src/pages/PreviewPage.jsx
+++ b/src/pages/PreviewPage.jsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 import ExperiencePreview from '../components/templates/Experience/ExperiencePreview'
 import CertificatePreview from '../components/templates/Certificate/CertificatePreview'
 import EducationPreview from '../components/templates/Education/EducationPreview'
+import UrlPreview from '../components/templates/Url/UrlPreview'
 
 export const LocalContext = createContext(null)
 
@@ -29,6 +30,7 @@ export default function PreviewPage() {
               <ExperiencePreview />
               <CertificatePreview />
               <EducationPreview />
+              <UrlPreview />
             </Layout>
           </Main>
           <Aside type="preview" />


### PR DESCRIPTION
## Summary
- 출력 페이지 URL컴포넌트를 구현했습니다.
- 미리보기 링크 박스(PreviewLink), 색상아이콘(ColorIcon) 컴포넌트 구현

## Description
### 구현 컴포넌트
1. PreviewLink
- 링크 주소를 **절대 경로**로 변경합니다. (ex. www.paullab.co.kr -> http://www.paullab.co.kr)
- 링크 클릭 시 새창에서 열립니다. `target="_blank"`

![PreviewLink](https://github.com/weniv/MAKE-RE_ver2/assets/96777064/2ffb163a-4847-4140-8fac-a19e9963e12a)

2. ColorIcon
- 메인 색상에 따라 색상이 변경되는 아이콘 컴포넌트입니다.
- 컴포넌트를 사용하는 곳에서 아이콘 이미지를 import 한 후, props.iconPath로 전달합니다.
```js
import iconPath from '../assets/icon/...'

<ColorIcon iconPath={iconPath} />
```
<img width="50" alt="스크린샷 2023-10-05 오전 9 39 27" src="https://github.com/weniv/MAKE-RE_ver2/assets/96777064/7ac41224-dc57-4416-80f5-4be243a0719e">


## Check
- [x] URL 값이 없을 때, URL 파트가 출력되지 않습니다.
- [x] URL이 www로 시작할 때,  새 창에서 해당 링크가 열립니다. (ex. www.github.com)
- [x] URL이 도메인이름으로 시작할 때,새창에서 해당 링크가 열립니다. (ex. github.com)
- [x] URL이 https://, http://로 시작할 때, 새창에서 해당 링크가 열립니다. (ex. http://www.github.com)  