### PR TITLE
📝 PR: Nav 드래그앤 드롭으로 미리보기 페이지 순서 변경 #134

### DIFF
--- a/src/components/organisms/Nav/NavBar.jsx
+++ b/src/components/organisms/Nav/NavBar.jsx
@@ -1,13 +1,13 @@
 import { styled } from 'styled-components'
 import NavList from '../../atoms/Nav/NavList'
-import { useContext, useState, useRef, useEffect } from 'react'
-import { remoteList } from '../../../data/dummy'
+import { useContext, useState } from 'react'
 import { Dnd } from '../../../utils'
 import RemoteContext from '../../../context/RemoteContext'
+import { ResumeContext } from '../../../context/ResumeContext'
 
 export default function NavBar({ type }) {
   const [isFill, setIsFill] = useState(false)
-  const [list, setList] = useState(remoteList)
+  const { navList, setNavList } = useContext(ResumeContext)
 
   const { currentSection, updateCurrentSection } = useContext(RemoteContext)
 
@@ -20,9 +20,9 @@ export default function NavBar({ type }) {
   }
 
   return (
-    <Dnd state={list} setState={setList}>
+    <Dnd state={navList} setState={setNavList}>
       <Nav>
-        {list.map((item, idx) => {
+        {navList.map((item, idx) => {
           return (
             <NavList
               clickIdx={currentSection.id}

--- a/src/components/templates/Profile/Profile.jsx
+++ b/src/components/templates/Profile/Profile.jsx
@@ -32,7 +32,7 @@ export default function Profile() {
   }, [])
 
   useEffect(() => {
-    console.log('profileData', profileData)
+    // console.log('profileData', profileData)
     setResumeData({ ...resumeData, profile: profileData })
   }, [profileData])
 

--- a/src/context/ResumeContext.jsx
+++ b/src/context/ResumeContext.jsx
@@ -1,15 +1,19 @@
 import React, { createContext, useEffect, useState } from 'react'
 import { resumeData as initialData } from '../data/dummy'
+import { remoteList } from '../data/dummy'
 
 export const ResumeContext = createContext(null)
 
 export default function ResumeProvider({ children }) {
   const data = JSON.parse(localStorage.getItem('resumeData'))
   const [resumeData, setResumeData] = useState(data ? data : initialData)
+  const [navList, setNavList] = useState(remoteList)
 
   return (
     <>
-      <ResumeContext.Provider value={{ resumeData, setResumeData }}>
+      <ResumeContext.Provider
+        value={{ resumeData, setResumeData, navList, setNavList }}
+      >
         {children}
       </ResumeContext.Provider>
     </>

--- a/src/pages/PreviewPage.jsx
+++ b/src/pages/PreviewPage.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState } from 'react'
+import React, { createContext, useContext, useState } from 'react'
 import Header from '../components/organisms/Header/Header'
 import Aside from '../components/templates/Aside/Aside'
 import ProfilePreview from '../components/templates/Profile/ProfilePreview'
@@ -10,15 +10,40 @@ import EducationPreview from '../components/templates/Education/EducationPreview
 import UrlPreview from '../components/templates/Url/UrlPreview'
 import CareerPreview from '../components/templates/Career/CareerPreview'
 import { ProjectPreview } from '../components/templates/Project'
+import { ResumeContext } from '../context/ResumeContext'
 
 export const LocalContext = createContext(null)
 
 export default function PreviewPage() {
+  const { navList } = useContext(ResumeContext)
   const getlocalData = () => {
     const data = localStorage.getItem('resumeData')
     return JSON.parse(data)
   }
+
   const [data, setData] = useState(getlocalData)
+
+  const components = {
+    프로필: ProfilePreview,
+    자기소개서: IntroPreview,
+    커리어: CareerPreview,
+    프로젝트: ProjectPreview,
+    경험: ExperiencePreview,
+    자격증: CertificatePreview,
+    교육: EducationPreview,
+    '추가 URL': UrlPreview,
+  }
+
+  const CurrentComponent = navList.map((el, index) => {
+    const Component = components[el.title]
+    return (
+      <div key={index}>
+        <Component />
+      </div>
+    )
+  })
+
+  // console.log('list', list)
 
   return (
     <>
@@ -27,14 +52,15 @@ export default function PreviewPage() {
         <Cont>
           <Main>
             <Layout>
-              <ProfilePreview />
+              {CurrentComponent}
+              {/* <ProfilePreview />
               <IntroPreview />
               <CareerPreview />
               <ProjectPreview />
               <ExperiencePreview />
               <CertificatePreview />
               <EducationPreview />
-              <UrlPreview />
+              <UrlPreview /> */}
             </Layout>
           </Main>
           <Aside type="preview" />

--- a/src/utils/dnd.jsx
+++ b/src/utils/dnd.jsx
@@ -18,6 +18,8 @@ export default function Dnd({ children, state, setState }) {
       const newIdx = state.findIndex((data) => data.id === over.id)
       return arrayMove(state, oldIdx, newIdx)
     })
+
+    // window.localStorage.setItem('order', JSON.stringify(state))
   }
 
   const Sort = (id) => {


### PR DESCRIPTION
# 📝 PR: Nav 드래그앤 드롭으로 미리보기 페이지 순서 변경 #134

## Summary
1. 작성 페이지에서 드래그앤 드롭을 통해 navList 리스트 순서를 변경하고, 그 순서에 따라 미리보기  페이지에서 컴포넌트를 동적으로 출력하는 기능 추가
2. 작성 페이지에서 변경한 navList 순서가 미리보기 페이지에서도 유지되도록 수정
3. 변경된 navList 순서가 새로고침 이전까지 유지되도록 수정

## Description
- `ResumeContext`에서 `navList` 데이터를 함께 관리하도록 수정하여, `navList`의 변경에 따라 미리보기 페이지의 컴포넌트도 동적으로 변경됩니다.

## Checklist
- [x] Nav 리스트 순서에 따라 미리보기 페이지의 컴포넌트가 동적으로 출력되는가?
- [x] 작성 페이지에서 변경된 Nav 리스트 순서가 미리보기 페이지의 Nav 리스트에서도 적용되는가?