### PR TITLE
✨ Fix: github아이디 인풋 및 기능 변경

### DIFF
--- a/src/api/GithubApi.jsx
+++ b/src/api/GithubApi.jsx
@@ -8,16 +8,19 @@ import ColorContext from '../context/ColorContext'
 import ThemeContext from '../context/ThemeContext'
 import AddImgIcon from '../assets/img-icon.svg'
 import AddImgIconDark from '../assets/img-icon-dark.svg'
+import { ResumeContext } from '../context/ResumeContext'
 
 export const GithubContext = React.createContext()
 
 export default function GithubApi({ children }) {
+  const { resumeData, setResumeData } = useContext(ResumeContext)
   const { themeMode } = useContext(ThemeContext)
   const imgIcon = themeMode === 'light' ? AddImgIcon : AddImgIconDark
 
   const [queryString, setQueryString] = useState(window.location.search)
   const { mainColor } = useContext(ColorContext)
   const [colorCode, setColorCode] = useState(mainColor.split('#')[1])
+  const [githubID, setGithubID] = useState(resumeData.github[0])
   const [userName, setUserName] = useState('')
   const [userData, setUserData] = useState([])
   const [chartData, setChartData] = useState({
@@ -235,12 +238,12 @@ export default function GithubApi({ children }) {
     setColorCode(mainColor)
   }, [mainColor])
 
-  useEffect(() => {
-    loadCommitImg()
-  }, [colorCode])
+  // useEffect(() => {
+  //   loadCommitImg()
+  // }, [colorCode])
 
   // 깃허브 잔디 이미지 불러오기
-  const [commitSrc, setCommitSrc] = useState('')
+  const [commitSrc, setCommitSrc] = useState(resumeData.github[1])
   const loadCommitImg = async () => {
     let src = ''
 
@@ -254,14 +257,40 @@ export default function GithubApi({ children }) {
     setCommitSrc(src)
   }
 
+  const loadCommitImgWithID = (e) => {
+    e.preventDefault()
+
+    if (githubID) {
+      const commitImg = `https://ghchart.rshah.org/${
+        colorCode.split('#')[1]
+      }/${githubID}`
+
+      setCommitSrc(commitImg)
+      setResumeData({ ...resumeData, github: [githubID, commitImg] })
+      console.log(commitSrc)
+    }
+  }
+
   return (
     <>
       <GitHubCont>
-        <form onSubmit={handleSubmit}>
-          <MainBtn type="preview" onClick={loadCommitImg}>
+        {/* <GithubForm onSubmit={handleSubmit}> */}
+        <GithubForm>
+          <div>
+            <label htmlFor="githubId">GitHub ID</label>
+            <input
+              id="githubId"
+              type="text"
+              value={githubID}
+              onChange={(e) => {
+                setGithubID(e.target.value)
+              }}
+            />
+          </div>
+          <MainBtn type="preview" onClick={loadCommitImgWithID}>
             내 잔디 불러오기
           </MainBtn>
-        </form>
+        </GithubForm>
       </GitHubCont>
 
       <Label>Contributions</Label>
@@ -362,6 +391,32 @@ const GitHubCont = styled(FlexBox)`
 
   button {
     align-self: flex-end;
+  }
+`
+
+const GithubForm = styled.form`
+  display: flex;
+  gap: 8px;
+  justify-content: flex-start;
+
+  div {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    gap: 8px;
+
+    label {
+      color: var(--gray-lv4-color);
+      font-size: 12px;
+    }
+
+    input {
+      width: 260px;
+      height: 42px;
+      padding: 11px 0 11px;
+      padding-left: 16px;
+      border-radius: 10px;
+    }
   }
 `
 

--- a/src/components/templates/Profile/ProfilePreview.jsx
+++ b/src/components/templates/Profile/ProfilePreview.jsx
@@ -8,10 +8,7 @@ export default function ProfilePreview() {
   const { data } = useContext(LocalContext)
   const { mainColor } = useContext(ColorContext)
   const profileData = data.profile
-  console.log('mainColor', mainColor)
-  const commitUrl = `https://ghchart.rshah.org/${
-    mainColor.split('#')[1]
-  }/${localStorage.getItem('userGithubId')}`
+  const commitUrl = data.github[1]
 
   return (
     <>


### PR DESCRIPTION
# 📝 PR: ✨ Fix: github아이디 인풋 및 기능 변경

## Summary

깃허브 토큰이용한 데이터 수집 => 깃허브 아이디로 커밋 이미지 가져오기 변경

## Description

- 기존 깃허브 토큰으로 데이터 수집하는 함수 주석처리 후 깃허브 아이디 인풋 및 저장 기능 추가
- 내 잔디 불러오기 버튼 클릭시 resumeData에 github: [깃허브 아이디, 커밋 이미지 src] 형식으로 저장
- 임시 저장 버튼 클릭시 로컬 스토리지에 저장
- 작성 페이지, 미리보기 페이지에서 받아온 데이터 렌더링

close: #124 