### PR TITLE
✨ Feat: 메인컬러 적용 파트 구분

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { WritePage, PreviewPage } from './pages'
 import ResumeProvider from './context/ResumeContext'
 import { RemoteProvider } from './context/RemoteContext'
 import { ThemeProvider } from './context/ThemeContext'
+import { PageTypeProvider } from './context/PageContext'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 
 function App() {
@@ -11,20 +12,22 @@ function App() {
     <div className="App">
       <ColorProvider>
         <ThemeProvider>
-          <RemoteProvider>
-            <GlobalStyles />
-            <ResumeProvider>
-              <BrowserRouter>
-                <Routes>
-                  <Route path="/MAKE-RE_ver2" element={<WritePage />} />
-                  <Route
-                    path="/MAKE-RE_ver2/preview"
-                    element={<PreviewPage />}
-                  />
-                </Routes>
-              </BrowserRouter>
-            </ResumeProvider>
-          </RemoteProvider>
+          <PageTypeProvider>
+            <RemoteProvider>
+              <GlobalStyles />
+              <ResumeProvider>
+                <BrowserRouter>
+                  <Routes>
+                    <Route path="/MAKE-RE_ver2" element={<WritePage />} />
+                    <Route
+                      path="/MAKE-RE_ver2/preview"
+                      element={<PreviewPage />}
+                    />
+                  </Routes>
+                </BrowserRouter>
+              </ResumeProvider>
+            </RemoteProvider>
+          </PageTypeProvider>
         </ThemeProvider>
       </ColorProvider>
     </div>

--- a/src/components/atoms/Button/MainBtn.jsx
+++ b/src/components/atoms/Button/MainBtn.jsx
@@ -1,17 +1,28 @@
+import { useContext } from 'react'
 import styled, { css } from 'styled-components'
+import PageTypeContext from '../../../context/PageContext'
+import ColorContext from '../../../context/ColorContext'
 import { ReactComponent as PlusIcon } from '../../../assets/icon-+.svg'
 
 // 미리보기, PDF 내보내기 버튼인 경우 162px로 고정임으로 type="preview"를 props로 내려보내 주어 너비 값 고정시키기
 // url, 경력, 프로젝트 추가 버튼인 경우 type설정 x
 export default function MainBtn({ onClick, children, type }) {
+  const { mainColor } = useContext(ColorContext)
+  const { pageType } = useContext(PageTypeContext)
+
   return (
     <>
       {type ? (
-        <MainButton onClick={onClick} type={type}>
+        <MainButton
+          mainColor={mainColor}
+          pageType={pageType}
+          onClick={onClick}
+          type={type}
+        >
           {children}
         </MainButton>
       ) : (
-        <MainButton onClick={onClick}>
+        <MainButton mainColor={mainColor} pageType={pageType} onClick={onClick}>
           <PlusIcon width="16px" height="16px" />
           {children}
         </MainButton>
@@ -27,7 +38,8 @@ const MainButton = styled.button`
       width: 162px;
     `}
   height: 42px;
-  background-color: var(--primary-color);
+  background-color: ${(props) =>
+    props.pageType === 'write' ? 'var(--primary-color)' : props.mainColor};
   border-radius: 10px;
   padding: 13px 20px;
   color: #fff;
@@ -35,9 +47,9 @@ const MainButton = styled.button`
   display: flex;
   justify-content: center;
   gap: 10px;
-  transition: background-color 0.1s ease-in;
+  transition: opacity 0.1s ease-in;
 
   &:hover {
-    background-color: var(--secondary-color);
+    opacity: 0.9;
   }
 `

--- a/src/components/atoms/Button/ToggleBtn.jsx
+++ b/src/components/atoms/Button/ToggleBtn.jsx
@@ -1,14 +1,23 @@
-import React, { useState, useContext } from 'react'
+import React, { useContext } from 'react'
 import styled, { css } from 'styled-components'
 import LightIcon from '../../../assets/icon-light-mode.svg'
 import DarkIcon from '../../../assets/icon-dark-mode.svg'
 import ThemeContext from '../../../context/ThemeContext'
+import PageTypeContext from '../../../context/PageContext'
+import ColorContext from '../../../context/ColorContext'
 
 export default function ToggleBtn({ onClick }) {
   const { themeMode, toggleTheme } = useContext(ThemeContext)
+  const { mainColor } = useContext(ColorContext)
+  const { pageType } = useContext(PageTypeContext)
 
   return (
-    <BtnCont onClick={toggleTheme} mode={themeMode}>
+    <BtnCont
+      mainColor={mainColor}
+      pageType={pageType}
+      onClick={toggleTheme}
+      mode={themeMode}
+    >
       <span className="ir">다크모드 온/오프 버튼</span>
       <Circle mode={themeMode} />
     </BtnCont>
@@ -24,7 +33,8 @@ const BtnCont = styled.button`
   border-radius: 40px;
   border: none;
   cursor: pointer;
-  background-color: var(--primary-color);
+  background-color: ${(props) =>
+    props.pageType === 'write' ? 'var(--primary-color)' : props.mainColor};
   position: relative;
   display: flex;
   justify-content: center;

--- a/src/components/atoms/ColorIcon/ColorIcon.jsx
+++ b/src/components/atoms/ColorIcon/ColorIcon.jsx
@@ -1,13 +1,16 @@
 import React, { useContext } from 'react'
 import styled from 'styled-components'
 import ColorContext from '../../../context/ColorContext'
+import PageTypeContext from '../../../context/PageContext'
 
 export default function ColorIcon({ type, iconPath, width, height }) {
+  const { pageType } = useContext(PageTypeContext)
   const { mainColor } = useContext(ColorContext)
 
   return (
     <>
       <Icon
+        pageType={pageType}
         color={mainColor}
         iconPath={iconPath}
         width={width}
@@ -22,7 +25,9 @@ const Icon = styled.div`
   width: ${(props) => props.width || '20px'};
   height: ${(props) => props.height || '20px'};
   border-radius: 50%;
-  background-color: ${(props) => props.className || props.color};
+  background-color: ${(props) =>
+    props.pageType === 'write' ? 'var(--primary-color)' : props.color};
+  background-color: ${(props) => props.className && 'inherit'};
   mask-image: url(${(props) => props.iconPath});
   mask-size: 100%;
   mask-repeat: no-repeat;

--- a/src/components/atoms/Nav/NavList.jsx
+++ b/src/components/atoms/Nav/NavList.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useContext } from 'react'
+import React, { useState, useEffect, useContext } from 'react'
 import styled, { css } from 'styled-components'
 import checkIcon from '../../../assets/icon-Check.svg'
 import { ReactComponent as CheckFillIcon } from '../../../assets/icon-Check-fill.svg'
@@ -6,6 +6,7 @@ import hamburgerIcon from '../../../assets/icon-hamburger.svg'
 import ColorContext from '../../../context/ColorContext'
 import { dndContext } from '../../../utils/dnd'
 import ColorIcon from '../ColorIcon/ColorIcon'
+import PageTypeContext from '../../../context/PageContext'
 
 export default function NavList({
   clickIdx,
@@ -15,7 +16,8 @@ export default function NavList({
   type,
   onClick,
 }) {
-  const { mainColor, upadteMainColor } = useContext(ColorContext)
+  const { mainColor } = useContext(ColorContext)
+  const { pageType } = useContext(PageTypeContext)
   const [clicked, setClickIdx] = useState(clickIdx === id)
 
   if (useContext(dndContext)) {
@@ -34,12 +36,20 @@ export default function NavList({
   }, [clickIdx])
 
   return (
-    <Cont key={id} isFill={true} clicked={clicked} onClick={onClick}>
+    <Cont
+      key={id}
+      isFill={true}
+      clicked={clicked}
+      onClick={onClick}
+      pageType={pageType}
+      color={mainColor}
+    >
       <>
         {isFill ? (
+          // NOTE: 다크모드 여부에 따른 primary-color 차이로 아래 컴포넌트 사용 필요
+          // <ColorIcon pageType={pageType} iconPath={CheckFillIcon} />
           <CheckFillIcon fill={mainColor} alt="입력 완료" />
         ) : (
-          // <ColorIcon iconPath={CheckFillIcon} type="nav" />
           <ColorIcon type="iconLv3" iconPath={checkIcon} />
         )}
         <NavText>{listName}</NavText>
@@ -50,7 +60,6 @@ export default function NavList({
             width="16px"
             height="16px"
           />
-          {/* <img src={hamburgerIcon} /> */}
         </DragBtn>
       </>
       {/* {type === 'write' ? (
@@ -102,7 +111,8 @@ const Cont = styled.div`
   ${(props) =>
     props.clicked &&
     css`
-      border: 2px solid var(--primary-color);
+      border: 2px solid
+        ${props.pageType === 'write' ? 'var(--primary-color)' : props.color};
       background-color: var(--gray-lv1-color);
     `}
 `

--- a/src/components/organisms/ColorPicker/ColorPicker.jsx
+++ b/src/components/organisms/ColorPicker/ColorPicker.jsx
@@ -1,14 +1,11 @@
 import { useContext, useEffect, useState, useRef } from 'react'
-import styled, { css } from 'styled-components'
 import { BlockPicker } from 'react-color'
+import styled, { css } from 'styled-components'
 import ColorPalette from '../../atoms/Nav/ColorPalette'
 import ColorContext from '../../../context/ColorContext'
-import ThemeContext from '../../../context/ThemeContext'
-import { lightTheme, darkTheme } from '../../../theme/theme'
 
 export default function ColorPicker() {
   const { mainColor, updateMainColor } = useContext(ColorContext)
-  const { themeMode } = useContext(ThemeContext)
   const [isOpen, setIsOpen] = useState(false)
 
   useEffect(() => {
@@ -40,35 +37,23 @@ export default function ColorPicker() {
       <Flexbox>
         <ColorPickerCont>
           <ColorPalette
-            // color="#2E6FF2"
-            // color={
-            //   themeMode === 'light'
-            //     ? lightTheme.codePurple
-            //     : darkTheme.codePurple
-            // }
-            color={(themeMode === 'light' ? lightTheme : darkTheme).codePurple}
+            color="var(--code-purple)"
             setColor={handleChangeComplete}
           ></ColorPalette>
           <ColorPalette
-            // color="#5F3AF2"
-            color={(themeMode === 'light' ? lightTheme : darkTheme).codePink}
+            color="var(--code-pink)"
             setColor={handleChangeComplete}
           ></ColorPalette>
           <ColorPalette
-            // color="#F2785C"
-            color={
-              (themeMode === 'light' ? lightTheme : darkTheme).primaryColor
-            }
+            color="var(--primary-color)"
             setColor={handleChangeComplete}
           ></ColorPalette>
           <ColorPalette
-            color={(themeMode === 'light' ? lightTheme : darkTheme).codeGreen}
+            color="var(--code-green)"
             setColor={handleChangeComplete}
-            setPickerOpen={setIsOpen}
           ></ColorPalette>
           <ColorPalette
-            // color="#0FA650"
-            color={(themeMode === 'light' ? lightTheme : darkTheme).codeOrange}
+            color="var(--code-orange)"
             setColor={handleChangeComplete}
           ></ColorPalette>
           <ColorPickerBtn

--- a/src/components/organisms/Nav/PreviewBox.jsx
+++ b/src/components/organisms/Nav/PreviewBox.jsx
@@ -1,11 +1,13 @@
 import { useContext } from 'react'
-import { styled } from 'styled-components'
-import { MainBtn, SaveBtn } from '../../atoms/Button'
-import { ResumeContext } from '../../../context/ResumeContext'
 import { useNavigate } from 'react-router-dom'
+import { styled } from 'styled-components'
+import { ResumeContext } from '../../../context/ResumeContext'
+import PageTypeContext from '../../../context/PageContext'
+import { MainBtn, SaveBtn } from '../../atoms/Button'
 
 export default function PreviewBox({ type }) {
   const { resumeData } = useContext(ResumeContext)
+  const { togglePageType } = useContext(PageTypeContext)
   const navigate = useNavigate()
 
   const saveLocalstorage = () => {
@@ -15,10 +17,12 @@ export default function PreviewBox({ type }) {
 
   const movePreview = () => {
     navigate('/MAKE-RE_ver2/preview')
+    togglePageType()
   }
 
   const moveHome = () => {
     navigate('/MAKE-RE_ver2/')
+    togglePageType()
   }
 
   return (

--- a/src/context/PageContext.jsx
+++ b/src/context/PageContext.jsx
@@ -1,0 +1,21 @@
+import React, { createContext, useState } from 'react'
+
+const PageTypeContext = createContext()
+
+export const PageTypeProvider = ({ children }) => {
+  const [pageType, setPageType] = useState('write')
+
+  const togglePageType = () => {
+    setPageType((prevPageType) =>
+      prevPageType === 'write' ? 'preview' : 'write'
+    )
+  }
+
+  return (
+    <PageTypeContext.Provider value={{ pageType, togglePageType }}>
+      {children}
+    </PageTypeContext.Provider>
+  )
+}
+
+export default PageTypeContext


### PR DESCRIPTION
# 📝 PR: 메인컬러 적용 파트 구분

## Summary

작성 페이지 / 미리보기 페이지 메인컬러 적용 파트 구분

## Description
- 작성 페이지: 기존 위니브 메인컬러 유지
- 미리보기 페이지: 토글 버튼, 로고, 메인 버튼 + pdf 출력 파트 전체적으로 mainColor 동적 적용

## Checklist

- [x] 작성 페이지에서는 기존 `primary-color`가 유지되는가
- [x] 미리보기 페이지에서는 모든 요소의 `mainColor`가 컬러 변경에 따라 적용되는가
- [x] 위 적용 사항이 다크모드 여부에 따라 동작하는가