### PR TITLE
📝 PR: PDF 내보내기 페이지 분할 기준 수정

### DIFF
--- a/src/components/templates/Career/CareerPreview.jsx
+++ b/src/components/templates/Career/CareerPreview.jsx
@@ -50,8 +50,11 @@ const Content = styled.div`
   display: flex;
   flex-direction: column;
   gap: 16px;
-  &:not(:first-child) {
-    break-inside: avoid;
+  break-inside: avoid;
+  page-break-inside: avoid;
+  &:first-child {
+    break-before: avoid;
+    page-break-before: avoid;
   }
 `
 const Title = styled.p`

--- a/src/components/templates/Certificate/CertificatePreview.jsx
+++ b/src/components/templates/Certificate/CertificatePreview.jsx
@@ -3,6 +3,7 @@ import { LocalContext } from '../../../pages/PreviewPage'
 import ColorContext from '../../../context/ColorContext'
 import { PreviewMonthItem } from '../../atoms/PreviewItem'
 import { PreviewSubtitle } from '../../atoms/Title'
+import styled from 'styled-components'
 
 export default function CertificatePreview() {
   const { data } = useContext(LocalContext)
@@ -24,7 +25,7 @@ export default function CertificatePreview() {
   return (
     <>
       {hasCertificates && (
-        <section>
+        <PreviewSection>
           <PreviewSubtitle>Certificate</PreviewSubtitle>
           {certificates.map((cert) => {
             const isInvalid = !cert.date
@@ -39,8 +40,13 @@ export default function CertificatePreview() {
               />
             )
           })}
-        </section>
+        </PreviewSection>
       )}
     </>
   )
 }
+
+const PreviewSection = styled.section`
+  page-break-inside: avoid;
+  break-inside: avoid;
+`

--- a/src/components/templates/Education/EducationPreview.jsx
+++ b/src/components/templates/Education/EducationPreview.jsx
@@ -22,7 +22,7 @@ export default function EducationPreview() {
   return (
     <>
       {hasEducation && (
-        <section>
+        <PreviewSection>
           <PreviewSubtitle>Education</PreviewSubtitle>
           {educationList.map((edu) => {
             const isInvalid =
@@ -41,8 +41,12 @@ export default function EducationPreview() {
               />
             )
           })}
-        </section>
+        </PreviewSection>
       )}
     </>
   )
 }
+const PreviewSection = styled.section`
+  page-break-inside: avoid;
+  break-inside: avoid;
+`

--- a/src/components/templates/Experience/ExperiencePreview.jsx
+++ b/src/components/templates/Experience/ExperiencePreview.jsx
@@ -3,6 +3,7 @@ import { LocalContext } from '../../../pages/PreviewPage'
 import ColorContext from '../../../context/ColorContext'
 import { PreviewMonthItem } from '../../atoms/PreviewItem'
 import { PreviewSubtitle } from '../../atoms/Title'
+import styled from 'styled-components'
 
 export default function ExperiencePreview() {
   const { data } = useContext(LocalContext)
@@ -21,7 +22,7 @@ export default function ExperiencePreview() {
   return (
     <>
       {hasExperience && (
-        <section>
+        <PreviewSection>
           <PreviewSubtitle>Experience</PreviewSubtitle>
           {expList.map((exp) => {
             const isInvalid =
@@ -40,8 +41,13 @@ export default function ExperiencePreview() {
               />
             )
           })}
-        </section>
+        </PreviewSection>
       )}
     </>
   )
 }
+
+const PreviewSection = styled.section`
+  page-break-inside: avoid;
+  break-inside: avoid;
+`

--- a/src/components/templates/Intro/IntroPreview.jsx
+++ b/src/components/templates/Intro/IntroPreview.jsx
@@ -12,15 +12,19 @@ export default function IntroPreview() {
   return (
     <>
       {introData && (
-        <section>
+        <IntroSection>
           <PreviewSubtitle>Introduction</PreviewSubtitle>
           <IntroCont>{introData}</IntroCont>
-        </section>
+        </IntroSection>
       )}
     </>
   )
 }
 
+const IntroSection = styled.div`
+  page-break-inside: avoid;
+  break-inside: avoid;
+`
 const IntroCont = styled.pre`
   width: 100%;
   font-size: 14px;

--- a/src/components/templates/Profile/ProfilePreview.jsx
+++ b/src/components/templates/Profile/ProfilePreview.jsx
@@ -8,7 +8,7 @@ export default function ProfilePreview() {
   const { data } = useContext(LocalContext)
   const { mainColor } = useContext(ColorContext)
   const profileData = data.profile
-  const commitUrl = data.github[1]
+  const commitUrl = data.github && data.github[1]
 
   return (
     <>

--- a/src/components/templates/Profile/ProfilePreview.jsx
+++ b/src/components/templates/Profile/ProfilePreview.jsx
@@ -11,71 +11,71 @@ export default function ProfilePreview() {
   const commitUrl = data.github && data.github[1]
 
   return (
-    <>
-      <ProfileSection>
-        {profileData?.profileImg && (
-          <ProfileImg mainColor={mainColor}>
-            <img src={profileData?.profileImg} alt="" />
-          </ProfileImg>
-        )}
+    <ProfileSection>
+      {profileData?.profileImg && (
+        <ProfileImg mainColor={mainColor}>
+          <img src={profileData?.profileImg} alt="" />
+        </ProfileImg>
+      )}
 
-        <ProfileBox mainColor={mainColor}>
-          <span>
-            <strong>{profileData?.name}</strong>
-            {profileData?.enName}
-          </span>
-          <DataList>
-            {/* 전화번호 */}
-            {profileData?.phoneNumber && (
-              <PreviewProfileItem
-                title="전화번호"
-                content={profileData?.phoneNumber}
-              ></PreviewProfileItem>
-            )}
-
-            {/* 이메일 */}
-            {profileData?.fullEmail !== '@' && (
-              <PreviewProfileItem
-                title="이메일"
-                content={profileData?.fullEmail}
-              ></PreviewProfileItem>
-            )}
-
-            {/* 기술 블로그 */}
-            {profileData?.blog && (
-              <PreviewProfileItem
-                title="기술 블로그"
-                type="link"
-                content={profileData?.blog}
-              ></PreviewProfileItem>
-            )}
-
-            {/* 경력사항 */}
+      <ProfileBox mainColor={mainColor}>
+        <span>
+          <strong>{profileData?.name}</strong>
+          {profileData?.enName}
+        </span>
+        <DataList>
+          {/* 전화번호 */}
+          {profileData?.phoneNumber && (
             <PreviewProfileItem
-              title="경력 사항"
-              content={
-                profileData.careerLength
-                  ? `${profileData?.careerLength}년차`
-                  : '신입'
-              }
+              title="전화번호"
+              content={profileData?.phoneNumber}
             ></PreviewProfileItem>
-            {commitUrl && (
-              <img
-                src={commitUrl}
-                className="commit"
-                alt="깃허브 커밋기록 이미지"
-              />
-            )}
-          </DataList>
-        </ProfileBox>
-      </ProfileSection>
-    </>
+          )}
+
+          {/* 이메일 */}
+          {profileData?.fullEmail !== '@' && (
+            <PreviewProfileItem
+              title="이메일"
+              content={profileData?.fullEmail}
+            ></PreviewProfileItem>
+          )}
+
+          {/* 기술 블로그 */}
+          {profileData?.blog && (
+            <PreviewProfileItem
+              title="기술 블로그"
+              type="link"
+              content={profileData?.blog}
+            ></PreviewProfileItem>
+          )}
+
+          {/* 경력사항 */}
+          <PreviewProfileItem
+            title="경력 사항"
+            content={
+              profileData.careerLength
+                ? `${profileData?.careerLength}년차`
+                : '신입'
+            }
+          ></PreviewProfileItem>
+          {commitUrl && (
+            <img
+              src={commitUrl}
+              className="commit"
+              alt="깃허브 커밋기록 이미지"
+            />
+          )}
+        </DataList>
+      </ProfileBox>
+    </ProfileSection>
   )
 }
 
 const ProfileSection = styled.section`
   display: flex;
   gap: 40px;
+  page-break-inside: avoid;
+  break-inside: avoid;
 `
 
 const ProfileImg = styled.div`

--- a/src/components/templates/Project/ProjectPreview.jsx
+++ b/src/components/templates/Project/ProjectPreview.jsx
@@ -20,7 +20,7 @@ export default function ProjectPreview() {
           <Project>
             {projectData &&
               projectData.map((data) => (
-                <div>
+                <ProjectItem>
                   <div className="description">
                     <PreviewMonthItem
                       startDate={
@@ -69,7 +69,7 @@ export default function ProjectPreview() {
                       <PreviewLink link={data.demoLink}></PreviewLink>
                     </div>
                   </LinkWrap>
-                </div>
+                </ProjectItem>
               ))}
           </Project>
         </section>
@@ -106,6 +106,14 @@ const Project = styled.section`
 
   & > * {
     break-inside: avoid;
+  }
+`
+const ProjectItem = styled.div`
+  break-inside: avoid;
+  page-break-inside: avoid;
+  &:first-child {
+    break-before: avoid;
+    page-break-before: avoid;
   }
 `
 

--- a/src/components/templates/Url/UrlPreview.jsx
+++ b/src/components/templates/Url/UrlPreview.jsx
@@ -14,7 +14,7 @@ export default function EducationPreview() {
   return (
     <>
       {!!urlList.length && (
-        <section>
+        <PreviewSection>
           <PreviewSubtitle>Url</PreviewSubtitle>
           <UrlListContainer>
             {urlList.map((url) => (
@@ -24,7 +24,7 @@ export default function EducationPreview() {
               </li>
             ))}
           </UrlListContainer>
-        </section>
+        </PreviewSection>
       )}
     </>
   )
@@ -45,4 +45,9 @@ const UrlListContainer = styled.ul`
 const UrlContent = styled.p`
   font-size: 16px;
   font-weight: 700;
+`
+
+const PreviewSection = styled.section`
+  page-break-inside: avoid;
+  break-inside: avoid;
 `

--- a/src/pages/PreviewPage.jsx
+++ b/src/pages/PreviewPage.jsx
@@ -100,8 +100,4 @@ const Layout = styled.div`
   gap: 40px;
   width: 890px;
   padding: 74px 52px;
-
-  & > * {
-    break-inside: avoid;
-  }
 `


### PR DESCRIPTION
## Summary
- PDF 내보내기(출력) 페이지 분할 기준 수정

## Description
### page-break
- Career, Project의 경우 항목 요소에 `break-inside:avoid;` 속성을 주어 해당 요소가 분할되지 않도록 수정
- 첫번째 항목 요소에 break-before:avoid도 함께 주어, 첫번째 항목 요소와 제목 요소가 함께 움직이도록 설정
- 나머지 항목은 섹션 전체에 `break-inside:avoid;`를 주어 섹션 단위로 이동할 수 있게 설정

### `page-break` vs `break`
- mdn 문서에는 page-break-~ 속성이 break-~로 변경되었다고 명시되어 있음.
- 호환성 유지를 위하여 두 속성값을 모두 갖도록 설정

# Checklist
- [x] 각 항목이 잘리지 않고 잘 출력되는가
- [x] Career, Project: 첫번째 요소가 제목과 분리되지 않고 함께 이동하는가?
- [x] Profile, Intro, Experience, Certificate, Education, URL은 섹션이 함께 이동하는가?