### PR TITLE
📝 PR: Project 미리보기 세부 타이틀 삭제 #164

### DIFF
--- a/src/components/atoms/Input/DefaultTextarea.jsx
+++ b/src/components/atoms/Input/DefaultTextarea.jsx
@@ -10,6 +10,7 @@ export default function DefaultTextarea({
   type,
   name,
   placeholder,
+  lineHeight,
   inputData,
   onChange,
   onKeyDown,
@@ -28,6 +29,7 @@ export default function DefaultTextarea({
         value={inputData}
         onChange={onChange}
         onKeyDown={onKeyDown}
+        lineHeight={lineHeight}
         rows={1}
       />
     </Cont>
@@ -52,7 +54,7 @@ const TextArea = styled.textarea`
   min-height: 42px;
   height: ${(props) => props.height};
   font-size: ${(props) => (props.type === 'intro' ? '16px' : '14px')};
-  line-height: ${(props) => props.type === 'intro' && '28px'};
+  line-height: ${(props) => props.lineHeight};
   margin-right: ${(props) => props.marginRight};
   padding: ${(props) => (props.type === 'intro' ? '20px' : '11px 16px')};
   border-radius: 10px;

--- a/src/components/organisms/Component/Project.jsx
+++ b/src/components/organisms/Component/Project.jsx
@@ -82,6 +82,7 @@ export default function Project({
             updateData(e, idx, projectData, setProjectData)
           }}
           inputData={project.outline}
+          lineHeight="18px"
         >
           {'프로젝트 설명'}
         </DefaultTextarea>

--- a/src/components/templates/Intro/Intro.jsx
+++ b/src/components/templates/Intro/Intro.jsx
@@ -44,6 +44,7 @@ export default function Intro() {
             height="516px"
             width="100%"
             type="intro"
+            line-height="28px"
             placeholder="예) 풀스택 웹 개발자를 꿈꾸는 홍길동입니다."
             onChange={handleUpdateIntro}
             inputData={intro}

--- a/src/components/templates/Project/ProjectPreview.jsx
+++ b/src/components/templates/Project/ProjectPreview.jsx
@@ -38,10 +38,7 @@ export default function ProjectPreview() {
                     <ProjectWrap>
                       <Title>{data.title}</Title>
                       <p className="outline">{data.outline}</p>
-                      <Title>
-                        인원 <span>{data.people}</span>
-                      </Title>
-                      <Title>적용기술</Title>
+                      <p>{data.people}</p>
                       <ul>
                         {data.skills
                           .filter((skill) => skill !== '')
@@ -49,7 +46,6 @@ export default function ProjectPreview() {
                             <Badge className="list">{skill}</Badge>
                           ))}
                       </ul>
-                      <Title>기여 부분</Title>
                       <ul>
                         {data.contributions
                           .filter((cont) => cont !== '')
@@ -98,8 +94,11 @@ const Project = styled.section`
     }
   }
 
-  p.outline {
+  p {
     font-size: 0.875rem;
+  }
+
+  p.outline {
     white-space: pre-wrap;
     line-height: 1.25rem;
   }


### PR DESCRIPTION
# 📝 PR: Project 미리보기 세부 타이틀 삭제 #164

## Summary
- Project 미리보기 컴포넌트의 세부 타이틀을 삭제
- 인원 항목의 폰트크기를 다른 항목들과 통일

## Description
- 아래와 같이 변경되었습니다.
![스크린샷 2023-10-26 102843](https://github.com/weniv/MAKE-RE_ver2/assets/81654172/e356940f-7f3e-44fe-b1bc-b983e8e0151d)