### PR TITLE
💄 UI: Skills 미리보기 섹션 구현

### DIFF
--- a/src/components/atoms/SkillList/SkillList.jsx
+++ b/src/components/atoms/SkillList/SkillList.jsx
@@ -7,12 +7,14 @@ import ColorIcon from '../ColorIcon/ColorIcon'
 // a작성페이지와 미리보기 페이지 모두 사용하는 UI로, 작성페이지에서는 type = "delete"를 props로 넘겨주어 닫기 아이콘 추가하도록 구현
 
 export default function SkillList({ children, onClick, type }) {
+  const { mainColor } = useContext(ColorContext)
+
   return (
     <>
       {children ? (
-        <SkillLi type={type} onClick={onClick}>
+        <SkillLi type={type} onClick={onClick} mainColor={mainColor}>
           <span>{children}</span>
-          {type && (
+          {type === 'delete' && (
             <button>
               <ColorIcon
                 type="iconLv1"
@@ -20,7 +22,6 @@ export default function SkillList({ children, onClick, type }) {
                 width="16px"
                 height="16px"
               />
-              {/* <img src={closeIcon} width={'16px'} height={'16px'} /> */}
             </button>
           )}
         </SkillLi>
@@ -30,19 +31,27 @@ export default function SkillList({ children, onClick, type }) {
 }
 
 const SkillLi = styled.li`
-  height: 40px;
+  height: ${(props) => (props.type === 'preview' ? '32px' : '40px')};
   display: inline-flex;
   align-items: center;
-  padding: ${(props) => (props.type ? '0 16px 0 20px' : '0 20px 0')};
+  padding: ${(props) =>
+    props.type === 'delete' ? '0 16px 0 20px' : '0 20px 0'}; // 작성페이지
+  padding: ${(props) =>
+    props.type === 'preview' && '0 14px'}; // 미리보기 페이지
   margin-right: 10px;
   gap: 6px;
   border-radius: 40px;
-  color: var(--primary-color);
-  border: 2px solid var(--primary-color);
+  color: ${(props) =>
+    props.type === 'preview' ? props.mainColor : 'var(--primary-color)'};
+  border: ${(props) =>
+    `2px solid ${
+      props.type === 'preview' ? props.mainColor : 'var(--primary-color)'
+    }`};
+  opacity: 0.9;
   background-color: var(--background-color);
   font-size: 14px;
   box-sizing: border-box;
-  cursor: pointer;
+  cursor: ${(props) => (props.type !== 'preview' ? 'pointer' : 'auto')};
 
   button {
     display: flex;

--- a/src/components/templates/Intro/IntroPreview.jsx
+++ b/src/components/templates/Intro/IntroPreview.jsx
@@ -2,11 +2,13 @@ import React, { useContext } from 'react'
 import { LocalContext } from '../../../pages/PreviewPage'
 import ColorContext from '../../../context/ColorContext'
 import { PreviewSubtitle } from '../../atoms/Title'
+import { SkillList } from '../../atoms/SkillList'
 import styled from 'styled-components'
 
 export default function IntroPreview() {
   const { data } = useContext(LocalContext)
   const { mainColor } = useContext(ColorContext)
+  const profileData = data.profile
   const introData = data.profile.intro
 
   return (
@@ -16,6 +18,16 @@ export default function IntroPreview() {
           <PreviewSubtitle>Introduction</PreviewSubtitle>
           <IntroCont>{introData}</IntroCont>
         </IntroSection>
+      )}
+      {profileData?.skills.length > 0 && (
+        <SkillSection>
+          <PreviewSubtitle type="skills">Skills</PreviewSubtitle>
+          {profileData.skills.map((skill, i) => (
+            <SkillList key={i} type="preview">
+              {skill}
+            </SkillList>
+          ))}
+        </SkillSection>
       )}
     </>
   )
@@ -31,4 +43,8 @@ const IntroCont = styled.pre`
   line-height: 20px;
   word-wrap: break-word;
   white-space: break-spaces;
+`
+
+const SkillSection = styled.section`
+  margin-top: 40px;
 `


### PR DESCRIPTION
# 📝 PR: Skills 미리보기 섹션 구현

## Summary
구버전 디자인에 맞춰 Skills 미리보기 섹션 구현

## Description
- 자기소개서 하단 배치
- Skills 타이틀 옆 아이템 일렬 배치 
- mainColor 동적 적용을 위한 `SkillList` 컴포넌트 내 `type='preview'` 추가 

## Example
![image](https://github.com/weniv/MAKE-RE_ver2/assets/80025366/29c28dd9-4886-4294-8984-63ead5a2089c)


close #180 