### PR TITLE
💄 Style: 탈퇴 완료 페이지 UI 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import GlobalStyles from './styles/GlobalStyles'
-import { WritePage, PreviewPage } from './pages'
+import { WritePage, PreviewPage, QuitPage } from './pages'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import Providers from './context/Providers'
 
@@ -12,6 +12,7 @@ function App() {
           <Routes>
             <Route path="/MAKE-RE_ver2" element={<WritePage />} />
             <Route path="/MAKE-RE_ver2/preview" element={<PreviewPage />} />
+            <Route path="/MAKE-RE_ver2/quit" element={<QuitPage />} />
           </Routes>
         </BrowserRouter>
       </Providers>

--- a/src/components/atoms/Button/MainBtn.jsx
+++ b/src/components/atoms/Button/MainBtn.jsx
@@ -5,6 +5,7 @@ import { ReactComponent as PlusIcon } from '../../../assets/icon-+.svg'
 
 // 미리보기, PDF 내보내기 버튼인 경우 162px로 고정임으로 type="preview"를 props로 내려보내 주어 너비 값 고정시키기
 // url, 경력, 프로젝트 추가 버튼인 경우 type설정 x
+// width:100% 인 경우 type='full'
 export default function MainBtn({ onClick, children, type, form }) {
   const { mainColor } = useContext(ColorContext)
 
@@ -30,6 +31,11 @@ export default function MainBtn({ onClick, children, type, form }) {
 }
 
 const MainButton = styled.button`
+  ${(props) =>
+    props.type === 'full' &&
+    css`
+      width: 100%;
+    `}
   ${(props) =>
     props.type === 'preview' &&
     css`

--- a/src/pages/QuitPage.jsx
+++ b/src/pages/QuitPage.jsx
@@ -1,0 +1,55 @@
+import { useNavigate } from 'react-router-dom'
+import styled from 'styled-components'
+import Header from '../components/organisms/Header/Header'
+import { MainBtn } from '../components/atoms/Button'
+
+export default function QuitPage() {
+  const navigate = useNavigate()
+
+  const moveMain = () => {
+    navigate('/MAKE-RE_ver2/')
+  }
+
+  return (
+    <>
+      <Header options={{ isCenter: true, isWhite: true }} />
+      <main>
+        <Wrap>
+          <img src="images/favicon.svg" alt="메이커리 파비콘" />
+          <Title>회원 탈퇴 완료</Title>
+          <Content>메이커리를 이용해 주셔서 감사합니다.</Content>
+          <MainBtn type="full" onClick={moveMain}>
+            메인으로
+          </MainBtn>
+        </Wrap>
+      </main>
+    </>
+  )
+}
+
+const Wrap = styled.div`
+  width: 322px;
+  margin: 120px auto 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  img {
+    width: 80px;
+    height: 80px;
+  }
+`
+
+const Title = styled.h2`
+  color: var(--surface-color);
+  font-size: 32px;
+  margin: 24px 0;
+  font-weight: 600;
+  line-height: 40px;
+`
+
+const Content = styled.p`
+  color: var(--gray-lv4-color);
+  margin-bottom: 24px;
+  line-height: 22px;
+`

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,2 +1,3 @@
 export { default as WritePage } from './WritePage'
 export { default as PreviewPage } from './PreviewPage'
+export { default as QuitPage } from './QuitPage'


### PR DESCRIPTION
# 📝 PR: 탈퇴 완료 페이지 UI 구현

## Summary
탈퇴 완료 페이지 UI 구현

## Description
- `width: 100%`인 MainBtn 사용 시 `type='full'` 지정 필요 (같은 '메인으로' 버튼이어도 너비가 다른 경우가 있음)
- 메인 페이지로 이동하는 함수는 편의상 추후 따로 분리하면 좋을 것 같습니다.

close #193 