### PR TITLE
🔥 Remove: 미리보기 페이지 드래그앤드롭 기능 제거

### DIFF
--- a/src/components/atoms/Nav/NavList.jsx
+++ b/src/components/atoms/Nav/NavList.jsx
@@ -7,14 +7,7 @@ import ColorContext from '../../../context/ColorContext'
 import { dndContext } from '../../../utils/dnd'
 import ColorIcon from '../ColorIcon/ColorIcon'
 
-export default function NavList({
-  clickIdx,
-  listName,
-  id,
-  isFill,
-  type,
-  onClick,
-}) {
+export default function NavList({ clickIdx, listName, id, type, onClick }) {
   const { mainColor } = useContext(ColorContext)
   const [clicked, setClickIdx] = useState(clickIdx === id)
 
@@ -34,46 +27,25 @@ export default function NavList({
   }, [clickIdx])
 
   return (
-    <Cont
-      key={id}
-      isFill={true}
-      clicked={clicked}
-      onClick={onClick}
-      color={mainColor}
-    >
+    <Cont key={id} clicked={clicked} onClick={onClick} color={mainColor}>
       <>
         <p>{listName}</p>
-        <DragBtn
-          ref={setNodeRef}
-          {...attributes}
-          {...listeners}
-          listName={listName}
-        >
-          <ColorIcon
-            type="iconLv3"
-            iconPath={hamburgerIcon}
-            width="16px"
-            height="16px"
-          />
-        </DragBtn>
-      </>
-      {/* {type === 'write' ? (
-        <>
-          {isFill ? (
-            <CheckFillIcon fill={mainColor} alt="입력 완료" />
-          ) : (
-            <img src={checkIcon} alt="입력 미완료" />
-          )}
-          <NavText>{listName}</NavText>
-          <DragBtn ref={setNodeRef} {...attributes} {...listeners}>
-            <img src={hamburgerIcon} />
+        {type === 'write' && (
+          <DragBtn
+            ref={setNodeRef}
+            {...attributes}
+            {...listeners}
+            listName={listName}
+          >
+            <ColorIcon
+              type="iconLv3"
+              iconPath={hamburgerIcon}
+              width="16px"
+              height="16px"
+            />
           </DragBtn>
-        </>
-      ) : (
-        <>
-          <NavText>{listName}</NavText>
-        </>
-      )} */}
+        )}
+      </>
     </Cont>
   )
 }

--- a/src/components/organisms/Nav/NavBar.jsx
+++ b/src/components/organisms/Nav/NavBar.jsx
@@ -3,12 +3,12 @@ import NavList from '../../atoms/Nav/NavList'
 import { useContext, useEffect, useState } from 'react'
 import { Dnd } from '../../../utils'
 import RemoteContext from '../../../context/RemoteContext'
-import { ResumeContext } from '../../../context/ResumeContext'
 import { saveData } from '../../../utils/saveData'
+import { remoteList } from '../../../data/dummy'
 
 export default function NavBar({ type }) {
-  const [isFill, setIsFill] = useState(false)
-  const { navList, setNavList } = useContext(ResumeContext)
+  const resumeOrder = JSON.parse(localStorage.getItem('resumeOrder'))
+  const [navList, setNavList] = useState(resumeOrder ? resumeOrder : remoteList)
 
   const { currentSection, updateCurrentSection } = useContext(RemoteContext)
 
@@ -20,10 +20,9 @@ export default function NavBar({ type }) {
     updateCurrentSection(val)
   }
 
-  //새로고침해도 변경된 nav 순서가 유지되는것이 좋지않을까
-  // useEffect(() => {
-  //   saveData('resumeOrder', JSON.stringify(navList))
-  // }, [navList])
+  useEffect(() => {
+    saveData('resumeOrder', JSON.stringify(navList))
+  }, [navList])
 
   return (
     <Dnd state={navList} setState={setNavList}>
@@ -36,7 +35,6 @@ export default function NavBar({ type }) {
               idx={idx}
               key={item.id}
               id={item.id}
-              isFill={isFill}
               type={type}
               onClick={() => {
                 handleClickList(item, idx)


### PR DESCRIPTION
# 📝 PR: 미리보기 페이지 드래그앤드롭 기능 제거

## Summary

- navBar 미리보기 페이지 드래그앤 드롭 버튼 제거
- 미리보기 항목 새로고침 시 유지

## Description

- navBar 미리보기 페이지 드래그앤 드롭 버튼 제거
 기존에 없던 기능인데, 체크박스 삭제하면서 미리보기 페이지에도 렌더링 되고 있어 기존 대로 type에 따라 조건부 렌더링 되도록 변경해두었습니다.

- 미리보기 항목 새로고침 시 유지
 간단한 기능이라 해당 코드 변경하면서 같이 변경했습니다. 현재는 resumeOrder라는 이름으로 이력서 하나의 항목만 관리되고 있고, 추후 api연동으로 여러 이력서 관리될 경우 이력서 고유 id값이나 인덱스값으로 이력서 구분해서 저장하도록 변경하겠습니다.

## Checklist

- [x] 새로고침시에 navList가 유지 되는가?
- [x] 미리보기 페이지에 드래그앤 드롭 버튼이 보이지 않는가?