### PR TITLE
💄 Style: 프로필, 자기소개 글자 색상 값 지정

### DIFF
--- a/src/components/templates/Intro/IntroPreview.jsx
+++ b/src/components/templates/Intro/IntroPreview.jsx
@@ -38,6 +38,7 @@ const IntroSection = styled.div`
   break-inside: avoid;
 `
 const IntroCont = styled.pre`
+  color: var(--surface-color);
   width: 100%;
   font-size: 14px;
   line-height: 20px;

--- a/src/components/templates/Profile/ProfilePreview.jsx
+++ b/src/components/templates/Profile/ProfilePreview.jsx
@@ -117,6 +117,7 @@ const ProfileBox = styled.div`
 `
 
 const DataList = styled.ul`
+  color: var(--surface-color);
   font-size: 14px;
 
   img.commit {


### PR DESCRIPTION
# 📝 PR: 프로필, 자기소개 글자 색상 값 지정

## Summary

- 스타일링 시 변수를 지정하지 않아 다크모드로 pdf 출력 시 변경된 색상 값이 적용되지 않는 이슈

## Description
- 변수 지정 필요 (ex. `color: var(--surface-color)` )