### PR TITLE
📝 PR: 아코디언 메뉴 컴포넌트 동작 버그 수정

### DIFF
--- a/src/components/organisms/Component/Career.jsx
+++ b/src/components/organisms/Component/Career.jsx
@@ -11,23 +11,18 @@ export default function Career({
   career,
   careerData,
   setCareerData,
-  activeIdx,
-  setActiveIdx,
   handleDelete,
+  activeAccordion,
+  onAccordionClick,
 }) {
   const [isStill, setIsStill] = useState(career.inProgress)
   const [textAreaHeight, setTextAreaHeight] = useState('auto')
-  const [isActive, setIsActive] = useState(0)
   const { formRef } = useContext(ResumeContext)
 
   const handleResizeTextArea = (height) => {
     setTextAreaHeight('auto')
     setTextAreaHeight(height)
   }
-
-  useEffect(() => {
-    setIsActive(activeIdx === idx)
-  }, [activeIdx])
 
   return (
     <ComponentHeader
@@ -36,9 +31,8 @@ export default function Career({
       kind={'커리어'}
       title={career.title ? career.title : null}
       handleDelete={handleDelete}
-      setActiveIdx={setActiveIdx}
-      isActive={isActive}
-      setIsActive={setIsActive}
+      isOpen={idx === activeAccordion}
+      onAccordionClick={() => onAccordionClick(idx)}
     >
       <Wrap>
         <form id="requiredForm" ref={formRef}>

--- a/src/components/organisms/Component/Certificate.jsx
+++ b/src/components/organisms/Component/Certificate.jsx
@@ -10,6 +10,8 @@ export default function Certificate({
   certData,
   setCertData,
   deleteCert,
+  activeAccordion,
+  onAccordionClick,
 }) {
   return (
     <ComponentHeader
@@ -17,6 +19,8 @@ export default function Certificate({
       kind="자격증"
       title={cert.title ? cert.title : null}
       handleDelete={deleteCert}
+      isOpen={idx === activeAccordion}
+      onAccordionClick={() => onAccordionClick(idx)}
     >
       <Wrap>
         <DefaultInput

--- a/src/components/organisms/Component/Education.jsx
+++ b/src/components/organisms/Component/Education.jsx
@@ -11,6 +11,8 @@ export default function Education({
   eduData,
   setEduData,
   deleteEdu,
+  activeAccordion,
+  onAccordionClick,
 }) {
   const [isStill, setIsStill] = useState(edu.inProgress)
 
@@ -20,6 +22,8 @@ export default function Education({
       id={edu.id}
       title={edu.title ? edu.title : null}
       handleDelete={deleteEdu}
+      isOpen={idx === activeAccordion}
+      onAccordionClick={() => onAccordionClick(idx)}
     >
       <Wrap>
         <DefaultInput

--- a/src/components/organisms/Component/Experience.jsx
+++ b/src/components/organisms/Component/Experience.jsx
@@ -12,6 +12,8 @@ export default function Experience({
   expData,
   setExpData,
   deleteExp,
+  activeAccordion,
+  onAccordionClick,
 }) {
   const [isStill, setIsStill] = useState(exp.inProgress)
 
@@ -22,6 +24,8 @@ export default function Experience({
         id={exp.id}
         title={exp.title || null}
         handleDelete={deleteExp}
+        isOpen={idx === activeAccordion}
+        onAccordionClick={() => onAccordionClick(idx)}
       >
         <Cont>
           <DefaultInput

--- a/src/components/organisms/Component/Project.jsx
+++ b/src/components/organisms/Component/Project.jsx
@@ -15,16 +15,11 @@ export default function Project({
   projectData,
   setProjectData,
   handleDelete,
-  activeIdx,
-  setActiveIdx,
+  activeAccordion,
+  onAccordionClick,
 }) {
   const [isStill, setIsStill] = useState(project.inProgress)
-  const [isActive, setIsActive] = useState(0)
   const { formRef } = useContext(ResumeContext)
-
-  useEffect(() => {
-    setIsActive(activeIdx === idx)
-  }, [activeIdx])
 
   return (
     <ComponentHeader
@@ -33,9 +28,8 @@ export default function Project({
       kind={'프로젝트'}
       title={project.title ? project.title : null}
       handleDelete={handleDelete}
-      setActiveIdx={setActiveIdx}
-      isActive={isActive}
-      setIsActive={setIsActive}
+      isOpen={idx === activeAccordion}
+      onAccordionClick={() => onAccordionClick(idx)}
     >
       <Wrap>
         <form id="requiredForm" ref={formRef}>

--- a/src/components/organisms/Component/Url.jsx
+++ b/src/components/organisms/Component/Url.jsx
@@ -4,7 +4,15 @@ import DefaultInput from '../../atoms/Input/DefaultInput'
 import { styled } from 'styled-components'
 import { updateData } from '../../../utils'
 
-export default function Url({ idx, url, urlData, setUrlData, deleteUrl }) {
+export default function Url({
+  idx,
+  url,
+  urlData,
+  setUrlData,
+  deleteUrl,
+  activeAccordion,
+  onAccordionClick,
+}) {
   return (
     <UrlItem>
       <ComponentHeader
@@ -12,6 +20,8 @@ export default function Url({ idx, url, urlData, setUrlData, deleteUrl }) {
         id={url.id}
         title={url.content || null}
         handleDelete={deleteUrl}
+        isOpen={idx === activeAccordion}
+        onAccordionClick={() => onAccordionClick(idx)}
       >
         <ItemCont>
           <DefaultInput

--- a/src/components/organisms/ComponentHeader/ComponentHeader.jsx
+++ b/src/components/organisms/ComponentHeader/ComponentHeader.jsx
@@ -9,14 +9,12 @@ import ColorIcon from '../../atoms/ColorIcon/ColorIcon'
 
 export default function ComponentHeader({
   id,
-  idx,
   kind,
   title,
   children,
   handleDelete,
-  setActiveIdx,
-  isActive,
-  setIsActive,
+  isOpen,
+  onAccordionClick,
 }) {
   if (useContext(dndContext)) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -27,20 +25,15 @@ export default function ComponentHeader({
 
   return (
     <styles.Cont style={style}>
-      <styles.Header>
+      <styles.Header onClick={onAccordionClick}>
         <styles.Btn ref={setNodeRef} {...attributes} {...listeners}>
           <ColorIcon iconPath={DragIcon} type="iconLv2" />
         </styles.Btn>
         <styles.Title>{title ? title : `새로운 ${kind}`}</styles.Title>
-        <styles.ExpandBtn
-          onClick={() => {
-            setActiveIdx(idx)
-            setIsActive(!isActive)
-          }}
-        >
+        <styles.ExpandBtn onClick={() => {}}>
           <ColorIcon
-            iconPath={!isActive ? expandIcon : reduceIcon}
-            isExpand={isActive}
+            iconPath={isOpen ? reduceIcon : expandIcon}
+            isExpand={true}
             type="iconLv1"
           />
         </styles.ExpandBtn>
@@ -49,18 +42,16 @@ export default function ComponentHeader({
         </styles.DelBtn>
       </styles.Header>
 
-      {isActive ? <styles.Component>{children}</styles.Component> : null}
+      {isOpen && <styles.Component>{children}</styles.Component>}
     </styles.Cont>
   )
 }
+
 ComponentHeader.defaultProps = {
   id: 0,
-  idx: 0,
   kind: '컴포넌트',
   title: '',
-  children: null,
   handleDelete: () => {},
-  setActiveIdx: () => {},
-  isActive: true,
-  setIsActive: () => {},
+  isOpen: false,
+  onAccordionClick: () => {},
 }

--- a/src/components/templates/Career/Career.jsx
+++ b/src/components/templates/Career/Career.jsx
@@ -11,7 +11,7 @@ import { ResumeContext } from '../../../context/ResumeContext'
 export default function Career() {
   const { resumeData, setResumeData } = useContext(ResumeContext)
   const [careerData, setCareerData] = useState(resumeData['career'])
-  const [activeIdx, setActiveIdx] = useState(0)
+  const [activeAccordion, setActiveAccordion] = useState(0)
 
   useEffect(() => {
     setResumeData({
@@ -48,6 +48,11 @@ export default function Career() {
     setCareerData(careerData.filter((career, i) => i !== idx))
   }
 
+  // 아코디언 오픈
+  const handleAccordionClick = (idx) => {
+    setActiveAccordion(idx === activeAccordion ? null : idx)
+  }
+
   return (
     <Dnd state={careerData} setState={setCareerData}>
       <Layout>
@@ -70,9 +75,9 @@ export default function Career() {
                   handleDelete={() => handleDelete(idx)}
                   careerData={careerData}
                   setCareerData={setCareerData}
-                  activeIdx={activeIdx}
-                  setActiveIdx={setActiveIdx}
                   key={idx}
+                  activeAccordion={activeAccordion}
+                  onAccordionClick={handleAccordionClick}
                 />
               ))}
           </ItemList>

--- a/src/components/templates/Career/Career.jsx
+++ b/src/components/templates/Career/Career.jsx
@@ -48,7 +48,7 @@ export default function Career() {
     setCareerData(careerData.filter((career, i) => i !== idx))
   }
 
-  // 아코디언 오픈
+  /** 아코디언 오픈 */
   const handleAccordionClick = (idx) => {
     setActiveAccordion(idx === activeAccordion ? null : idx)
   }

--- a/src/components/templates/Certificate/Certificate.jsx
+++ b/src/components/templates/Certificate/Certificate.jsx
@@ -10,6 +10,7 @@ import { Dnd } from '../../../utils'
 export default function Certificate() {
   const { resumeData } = useContext(ResumeContext)
   const [certData, setCertData] = useState(resumeData['certificate'])
+  const [activeAccordion, setActiveAccordion] = useState(0)
 
   useEffect(() => {
     resumeData['certificate'] = [...certData]
@@ -41,6 +42,11 @@ export default function Certificate() {
     setCertData(certData.filter((cert, i) => i !== idx))
   }
 
+  /** 아코디언 오픈 */
+  const handleAccordionClick = (idx) => {
+    setActiveAccordion(idx === activeAccordion ? null : idx)
+  }
+
   return (
     <Dnd state={certData} setState={setCertData}>
       <Layout>
@@ -62,6 +68,8 @@ export default function Certificate() {
                   certData={certData}
                   setCertData={setCertData}
                   key={idx}
+                  activeAccordion={activeAccordion}
+                  onAccordionClick={handleAccordionClick}
                 />
               ))}
           </ItemList>

--- a/src/components/templates/Education/Education.jsx
+++ b/src/components/templates/Education/Education.jsx
@@ -10,6 +10,7 @@ import { Dnd } from '../../../utils'
 export default function Education() {
   const { resumeData } = useContext(ResumeContext)
   const [eduData, setEduData] = useState(resumeData['education'])
+  const [activeAccordion, setActiveAccordion] = useState(0)
 
   useEffect(() => {
     resumeData['education'] = [...eduData]
@@ -42,6 +43,12 @@ export default function Education() {
   const deleteEdu = (idx) => {
     setEduData(eduData.filter((edu, i) => i !== idx))
   }
+
+  /** 아코디언 오픈 */
+  const handleAccordionClick = (idx) => {
+    setActiveAccordion(idx === activeAccordion ? null : idx)
+  }
+
   return (
     <Dnd state={eduData} setState={setEduData}>
       <Layout>
@@ -63,6 +70,8 @@ export default function Education() {
                   eduData={eduData}
                   setEduData={setEduData}
                   key={idx}
+                  activeAccordion={activeAccordion}
+                  onAccordionClick={handleAccordionClick}
                 />
               ))}
           </ItemList>

--- a/src/components/templates/Experience/Experience.jsx
+++ b/src/components/templates/Experience/Experience.jsx
@@ -10,6 +10,7 @@ import { Dnd } from '../../../utils'
 export default function Experience() {
   const { resumeData } = useContext(ResumeContext)
   const [expData, setExpData] = useState(resumeData['experience'])
+  const [activeAccordion, setActiveAccordion] = useState(0)
 
   useEffect(() => {
     resumeData['experience'] = [...expData]
@@ -45,6 +46,11 @@ export default function Experience() {
     setExpData(expData.filter((exp, i) => i !== idx))
   }
 
+  /** 아코디언 오픈 */
+  const handleAccordionClick = (idx) => {
+    setActiveAccordion(idx === activeAccordion ? null : idx)
+  }
+
   return (
     <Dnd state={expData} setState={setExpData}>
       <Layout>
@@ -66,6 +72,8 @@ export default function Experience() {
                   expData={expData}
                   setExpData={setExpData}
                   key={idx}
+                  activeAccordion={activeAccordion}
+                  onAccordionClick={handleAccordionClick}
                 />
               ))}
           </ItemList>

--- a/src/components/templates/Project/Project.jsx
+++ b/src/components/templates/Project/Project.jsx
@@ -11,7 +11,7 @@ import { ResumeContext } from '../../../context/ResumeContext'
 export default function Project() {
   const { resumeData, setResumeData } = useContext(ResumeContext)
   const [projectData, setProjectData] = useState(resumeData['project'])
-  const [activeIdx, setActiveIdx] = useState(0)
+  const [activeAccordion, setActiveAccordion] = useState(0)
 
   useEffect(() => {
     setResumeData({
@@ -55,6 +55,11 @@ export default function Project() {
     setProjectData(projectData.filter((pro, i) => i !== idx))
   }
 
+  /** 아코디언 오픈 */
+  const handleAccordionClick = (idx) => {
+    setActiveAccordion(idx === activeAccordion ? null : idx)
+  }
+
   return (
     <Dnd state={projectData} setState={setProjectData}>
       <Layout>
@@ -78,8 +83,8 @@ export default function Project() {
                   projectData={projectData}
                   setProjectData={setProjectData}
                   handleDelete={() => handleDelete(idx)}
-                  activeIdx={activeIdx}
-                  setActiveIdx={setActiveIdx}
+                  activeAccordion={activeAccordion}
+                  onAccordionClick={handleAccordionClick}
                   key={idx}
                 />
               ))}

--- a/src/components/templates/Url/Url.jsx
+++ b/src/components/templates/Url/Url.jsx
@@ -9,6 +9,7 @@ import { MainBtn } from '../../atoms/Button'
 export default function Url() {
   const { resumeData } = useContext(ResumeContext)
   const [urlData, setUrlData] = useState(resumeData['url'])
+  const [activeAccordion, setActiveAccordion] = useState(0)
 
   useEffect(() => {
     resumeData['url'] = [...urlData]
@@ -40,6 +41,11 @@ export default function Url() {
     setUrlData(urlData.filter((url, i) => i !== idx))
   }
 
+  /** 아코디언 오픈 */
+  const handleAccordionClick = (idx) => {
+    setActiveAccordion(idx === activeAccordion ? null : idx)
+  }
+
   return (
     <Dnd state={urlData} setState={setUrlData}>
       <Layout>
@@ -61,6 +67,8 @@ export default function Url() {
                   urlData={urlData}
                   setUrlData={setUrlData}
                   key={idx}
+                  activeAccordion={activeAccordion}
+                  onAccordionClick={handleAccordionClick}
                 />
               ))}
           </ItemList>


### PR DESCRIPTION
# 📝 PR: 아코디언 메뉴 컴포넌트 동작 버그 수정

## ✏️ 요약
- 커리어, 프로젝트, 경험, 자격증, 교육, 추가URL 컴포넌트 아코디언 메뉴가 제대로 펼쳐지지않는 오류 존재

## 👩‍💻 작업내용
- 한번에 하나의 아코디언 메뉴만 오픈되도록 수정
- 초기에는 0번 메뉴가 열려있도록 수정

## 🔍 참고사항
- `ComponentHeader` 컴포넌트 props 추가
   -  isOpen
   - onAccordionClick
  
## ✅ 체크리스트
### [Feat] 잘 동작하는가
- [x]  window