### PR TITLE
📝 PR: 프로젝트 설명 파트 PDF 출력시 다크 모드 적용안되는 문제 해결 #231

### DIFF
--- a/src/components/templates/Project/ProjectPreview.jsx
+++ b/src/components/templates/Project/ProjectPreview.jsx
@@ -103,6 +103,7 @@ const Project = styled.section`
   p.outline {
     white-space: pre-wrap;
     line-height: 2rem;
+    color: var(--surface-color);
   }
 
   & > * {


### PR DESCRIPTION
# 📝 PR: 프로젝트 설명 파트 PDF 출력시 다크 모드 적용안되는 문제 해결 #231

## ✏️ 요약
-다크모드 적용 후 PDF 출력시 미리보기창에서 프로젝트 설명 파트가 다크모드가 적용되지않는 문제가 있었음
- 미리보기시에는 문제가 발생하지않

## 👩‍💻 작업내용
- `ProjectPreview.jsx` 컴포넌트 outline 클래스에 color 속성 추가

## ✅ 체크리스트
### [UI] 화면에 잘 나오는가
- [X] PC
- [] Moblie

### [OS] 화면에 잘 나오는가
- [X] Window
- [] Mac

### [Feat] 잘 동작하는가
<!-- 해당 기능에 대해서 테스트 해주세요. 스크린샷, gif 등을 첨부하셔도 좋습니다.-->
<img src="https://github.com/weniv/MAKE-RE_ver2/assets/81654172/79e4752a-24f9-4b33-ab44-c9a499247ff9" width="600px" />

