### PR TITLE
📝 PR: 소셜 로그인기능 삭제 및 로그인/회원가입 페이지 UI 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,7 @@ function App() {
             <Route path="/MAKE-RE_ver2/quit" element={<QuitPage />} />
             <Route path="/MAKE-RE_ver2/login" element={<LoginPage />} />
             <Route path="/MAKE-RE_ver2/signup" element={<SignupPage />} />
-            <Route path="/MAKE-RE_ver2/done" element={<SignupDonePage />} />
+            {/* <Route path="/MAKE-RE_ver2/done" element={<SignupDonePage />} /> */}
             <Route path="/MAKE-RE_ver2/myresume" element={<MyResumePage />} />
             <Route
               path="/MAKE-RE_ver2/profilesetting"

--- a/src/components/atoms/Auth/Layout.jsx
+++ b/src/components/atoms/Auth/Layout.jsx
@@ -2,11 +2,11 @@ import React from 'react'
 import Header from '../../organisms/Header/Header'
 import styled from 'styled-components'
 
-export default function Layout({ children }) {
+export default function Layout({ children, auth }) {
   return (
     <>
       <Header options={{ isCenter: true, isWhite: true }} />
-      <Section>
+      <Section auth={auth}>
         <Content>{children}</Content>
       </Section>
     </>
@@ -15,11 +15,12 @@ export default function Layout({ children }) {
 
 const Section = styled.section`
   display: flex;
-  align-items: center;
+  align-items: ${(props) => (props.auth ? 'start' : 'center')};
   justify-content: center;
   position: relative;
   width: 100vw;
-  height: calc(100vh - 71px);
+  height: calc(100% - 71px);
+  margin-top: ${(props) => (props.auth ? '60px' : '0')};
 `
 
 const Content = styled.div`

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -56,7 +56,7 @@ export default function LoginPage() {
   }
 
   return (
-    <Layout>
+    <Layout auth>
       <Logo />
       <Description>
         메이커리 로그인 후<br />
@@ -100,7 +100,7 @@ export default function LoginPage() {
           비밀번호 찾기
         </p>
       </Redirect>
-      <Line>
+      {/* <Line>
         <p className="or">또는</p>
       </Line>
       <Button className="github social" onClick={githubLogin}>
@@ -108,7 +108,7 @@ export default function LoginPage() {
       </Button>
       <Button className="google social" onClick={googleLogin}>
         Google 계정으로 로그인
-      </Button>
+      </Button> */}
     </Layout>
   )
 }

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -81,11 +81,11 @@ export default function SignupPage() {
 
   // 회원가입 완료
   const submitSignup = () => {
-    navigate('/MAKE-RE_ver2/done')
+    navigate('/MAKE-RE_ver2/profilesetting')
   }
 
   return (
-    <Layout>
+    <Layout auth>
       <Title>회원가입</Title>
       <Form id="signupForm" method="POST" onSubmit={submitSignup}>
         <EmailWrap id="signupEmailForm" isValidate={isValidate}>


### PR DESCRIPTION
# 📝 PR: 소셜 로그인기능 삭제 및 로그인/회원가입 페이지 UI 수정

## Summary
- 소셜 로그인 기능이 삭제됨에따라 로그인 페이지에서 소셜 로그인 버튼 삭제
- `src\components\atoms\Auth\Layout.jsx` props로 auth 추가 (로그인, 회원가입 페이지에서 사용)
  - auth=true의 경우, section에 적용된 align-item을 center에서 start로 변경
  - auth=true의 경우, margin-top: 60px 추가
- 회원가입 완료시 기본 프로필 설정 페이지로 이동하도록 수정 (기존에는 회원가입 완료 페이지 출력)

## Checklist
- [x] 깃허브 로그인 삭제
- [x] 구글 로그인 삭제
- [X] 회원가입 완료시 `/done` 에서 `/profilesetting`으로 아동하도록 수정 