### PR TITLE
📝 PR: 출력 여백 설정 및 라이트모드 지정

### DIFF
--- a/src/components/organisms/Nav/PreviewBox.jsx
+++ b/src/components/organisms/Nav/PreviewBox.jsx
@@ -6,6 +6,8 @@ import { MainBtn, SaveBtn } from '../../atoms/Button'
 import { useReactToPrint } from 'react-to-print'
 import { saveData } from '../../../utils/saveData'
 import { checkRequiredValidity } from '../../atoms/Input/RequireInput'
+import ThemeContext from '../../../context/ThemeContext'
+import { theme } from '../../../theme/theme'
 
 export default function PreviewBox({ type, ...props }) {
   const { resumeData, formRef } = useContext(ResumeContext)

--- a/src/pages/PreviewPage.jsx
+++ b/src/pages/PreviewPage.jsx
@@ -19,6 +19,7 @@ import { ProjectPreview } from '../components/templates/Project'
 import { ResumeContext } from '../context/ResumeContext'
 import Footer from '../components/organisms/Footer/Footer'
 import RemoteContext from '../context/RemoteContext'
+import { lightTheme } from '../theme/theme'
 
 export const LocalContext = createContext(null)
 
@@ -62,11 +63,9 @@ export default function PreviewPage() {
       <Header options={{ hasProfile: true }} />
       <LocalContext.Provider value={{ data, setData }}>
         <Cont>
-          <Margin ref={exportRef}>
-            <Main ref={exportRef}>
-              <Layout>{CurrentComponent}</Layout>
-            </Main>
-          </Margin>
+          <Main ref={exportRef}>
+            <Layout className="cont-print">{CurrentComponent}</Layout>
+          </Main>
           <Aside type="preview" exportRef={exportRef} scrollRef={scrollRef} />
         </Cont>
       </LocalContext.Provider>
@@ -95,11 +94,15 @@ const Main = styled.main`
   height: fit-content;
 
   @page {
-    size: A4;
-    margin: 0mm;
+    size: 210mm 297mm;
+    margin: 20mm 20mm 15mm;
   }
   @media print {
-    padding: 10mm;
+    * {
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
+    }
+    zoom: 80%;
   }
 `
 
@@ -109,9 +112,7 @@ const Layout = styled.div`
   gap: 40px;
   width: 890px;
   padding: 74px 52px;
-`
-
-const Margin = styled.div`
   @media print {
+    padding: 0;
   }
 `

--- a/src/pages/PreviewPage.jsx
+++ b/src/pages/PreviewPage.jsx
@@ -95,7 +95,7 @@ const Main = styled.main`
 
   @page {
     size: 210mm 297mm;
-    margin: 20mm 20mm 15mm;
+    margin: 20mm;
   }
   @media print {
     * {

--- a/src/styles/GlobalStyles.jsx
+++ b/src/styles/GlobalStyles.jsx
@@ -1,5 +1,6 @@
 import { createGlobalStyle } from 'styled-components'
 import reset from 'styled-reset'
+import { lightTheme } from '../theme/theme'
 
 const GlobalStyles = createGlobalStyle`
     :root {
@@ -26,6 +27,30 @@ const GlobalStyles = createGlobalStyle`
 
     }
     ${reset}
+    @media print {
+        :root {
+            --primary-color:  ${lightTheme.primaryColor};
+            --secondary-color: ${lightTheme.secondaryColor};
+            --activation-color: ${lightTheme.activationColor};
+            --background-color: ${lightTheme.backgroundColor};
+            --surface-color: ${lightTheme.surfaceColor};
+            --gray-lv1-color: ${lightTheme.grayLv1Color};
+            --gray-lv2-color: ${lightTheme.grayLv2Color};
+            --gray-lv3-color: ${lightTheme.grayLv3Color};
+            --gray-lv4-color: ${lightTheme.grayLv4Color};
+            --error-color: ${lightTheme.errorColor};
+
+            --code-purple: ${lightTheme.codePurple};
+            --code-pink: ${lightTheme.codePink};
+            --code-blue: ${lightTheme.codeBlue};
+            --code-green: ${lightTheme.codeGreen};
+            --code-orange: ${lightTheme.codeOrange};
+
+            
+            
+            --shadow: ${lightTheme.shadow};
+        }
+    }
 
     @font-face {
         font-family: 'Pretendard';


### PR DESCRIPTION
## Summary
- PDF 내보내기 여백 설정
- 출력 라이트 모드 지정

## Description
![image](https://github.com/weniv/MAKE-RE_ver2/assets/96777064/6d696d3b-50b7-4915-a9bf-bd4a2256a0d6)

### 1. 페이지 여백 설정
- @page 스타일링을 통해 인쇄 옵션을 설정
```css
 @page {
    size: 210mm 297mm;
    margin: 20mm;
  }
```

- 다크모드에서 여백은 배경색상이 지정되지 않음. 
- 미디어 쿼리를 이용하여 print인 경우에 라이트 모드 변수를 사용 `✅ 현재 적용된 방식`
```css
@media print {
        :root {
            --primary-color:  ${lightTheme.primaryColor};
            --secondary-color: ${lightTheme.secondaryColor};
         (생략)
```

### 2. 여백 미지정 
- 사용자 입력에 따라 페이지 분할 위치가 다름
- 페이지에 옵션을 제거하고, 출력할 컴포넌트에 padding을 조절하면 분할 위치마다 여백이 적용되지 않음

## Checklist
- [x] 출력 시 각 페이지마다 여백이 잘 적용되는가?
close #260 