### PR TITLE
📝 PR: 마이페이지 이력서 수정 및 삭제 버튼 수정

### DIFF
--- a/src/components/organisms/Component/Resume.jsx
+++ b/src/components/organisms/Component/Resume.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useContext } from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import EditIcon from '../../../assets/icon-pencil.svg'
+import DeleteIcon from '../../../assets/icon-X.svg'
 import MoreIcon from '../../../assets/icon-more.svg'
 import ColorIcon from '../../atoms/ColorIcon/ColorIcon'
 import { DefaultInput } from '../../atoms/Input'
@@ -58,6 +59,8 @@ export default function Resume({ id }) {
     document.addEventListener('mousedown', handleClickOutside)
   }, [menuRef])
 
+  console.log('isModalOpen', isModalOpen)
+
   return (
     <>
       <Cont>
@@ -73,7 +76,9 @@ export default function Resume({ id }) {
               />
             ) : (
               <>
-                <Title>{resumeName}</Title>
+                <Link to={`/write/${id}`}>
+                  <Title>{resumeName}</Title>
+                </Link>
                 <button onClick={() => setEditable(true)}>
                   <ColorIcon
                     iconPath={EditIcon}
@@ -85,7 +90,15 @@ export default function Resume({ id }) {
               </>
             )}
           </TitleWrap>
-          <MoreBtn
+          <DeleteBtn onClick={() => setModalOpen(true)}>
+            <ColorIcon
+              iconPath={DeleteIcon}
+              type="iconLv2"
+              width="20px"
+              height="20px"
+            />
+          </DeleteBtn>
+          {/* <MoreBtn
             onClick={handleToggleMenu}
             ref={menuRef}
             isEditable={isEditable}
@@ -108,7 +121,7 @@ export default function Resume({ id }) {
                 </li>
               </MenuList>
             )}
-          </MoreBtn>
+          </MoreBtn> */}
         </Wrap>
         <EditDate>마지막 수정: 2023.11.01</EditDate> {/* resume.update_at */}
       </Cont>
@@ -147,12 +160,18 @@ const Title = styled.h3`
   margin-right: 8px;
   font-weight: 700;
   color: var(--surface-color);
+
+  &:hover {
+    text-decoration: underline;
+  }
 `
 
 const EditDate = styled.span`
   color: var(--gray-lv4-color);
   font-size: 12px;
 `
+
+const DeleteBtn = styled.button``
 
 const MoreBtn = styled.button`
   position: absolute;

--- a/src/components/templates/Career/Career.jsx
+++ b/src/components/templates/Career/Career.jsx
@@ -15,10 +15,6 @@ export default function Career({ id }) {
   const [activeAccordion, setActiveAccordion] = useState(0)
 
   useEffect(() => {
-    // setResumeData({
-    //   ...resumeData,
-    //   career: careerData.filter((el, idx) => idx === 0 || !!el.title),
-    // })
     setResumeData((prevResumeData) => {
       const updatedResumeData = prevResumeData.map((resume) => {
         if (String(resume.id) === id) {

--- a/src/components/templates/Profile/Profile.jsx
+++ b/src/components/templates/Profile/Profile.jsx
@@ -10,11 +10,9 @@ import { uploadImg, deleteImg } from '../../../utils'
 import { updateProfile } from '../../../utils'
 import { domainList, careerList } from '../../../data/profileDropbox'
 import LicatFace from '../../../assets/icon-liacat.svg'
-import ProfileExImg from '../../../assets/icon-profileEx.svg'
 import * as styles from './Profile-style'
 import ColorContext from '../../../context/ColorContext'
 import GithubApi from '../../../api/GithubApi'
-import { ProfileContext } from '../../../context/ProfileContext'
 
 export default function Profile({ id, type, setIsReady }) {
   const { resumeData, setResumeData } = useContext(ResumeContext)


### PR DESCRIPTION
# 📝 PR: 마이페이지 이력서 수정 및 삭제 버튼 수정
- 더보기 버튼 내부에 있던 이력서 수정 및 삭제 버튼을 외부로 이동

## Description
- 이력서 이름 클릭시 이력서 수정 페이지로 이동
  - 이력서 이름 hover 시 text-decoration: underline 추가
- 더보기 버튼을 삭제버튼으로 수정 후 이력서 삭제 기능을 수행하도록 변경

## Checklist
- [ ] 이력서 수정이 잘 되는가?
- [ ] 이력서 삭제가 잘 되는가?