### PR TITLE
🐛 Fix: 기본 프로필 하단 저장 버튼 에러 수정

### DIFF
--- a/src/components/templates/Profile/DefaultProfile.jsx
+++ b/src/components/templates/Profile/DefaultProfile.jsx
@@ -12,7 +12,6 @@ import LicatFace from '../../../assets/icon-liacat.svg'
 import * as styles from './Profile-style'
 import ColorContext from '../../../context/ColorContext'
 import GithubApi from '../../../api/GithubApi'
-import { ProfileContext } from '../../../context/ProfileContext'
 import { MainBtn } from '../../atoms/Button'
 import { saveData } from '../../../utils/saveData'
 
@@ -100,8 +99,8 @@ export default function DefaultProfile({ type }) {
   }
 
   return (
-    <Layout>
-      <>
+    <>
+      <Layout>
         <styles.Section>
           <styles.TitleCont>
             <WriteTitle
@@ -303,7 +302,14 @@ export default function DefaultProfile({ type }) {
           <WriteSubtitle subtitle="GitHub" id="github" />
           <GithubApi />
         </styles.Section>
-      </>
-    </Layout>
+      </Layout>
+      <styles.Button
+        onClick={() => {
+          saveProfile(profileData)
+        }}
+      >
+        저장하기
+      </styles.Button>
+    </>
   )
 }

--- a/src/components/templates/Profile/Profile-style.jsx
+++ b/src/components/templates/Profile/Profile-style.jsx
@@ -96,3 +96,14 @@ export const SkillListWrap = styled.div`
   flex-wrap: wrap;
   gap: 6px;
 `
+
+export const Button = styled.button`
+  width: 240px;
+  border-radius: 10px;
+  background-color: var(--primary-color);
+  padding: 11px 0;
+  color: var(--background-color);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+`

--- a/src/context/ProfileContext.jsx
+++ b/src/context/ProfileContext.jsx
@@ -13,7 +13,7 @@ export default function ProfileProvider({ children }) {
   useEffect(() => {
     // 컴포넌트가 처음 마운트될 때 한 번만 실행
     if (!storedData) {
-      // 로컬 스토리지에 'profileData'가 없거나 유효한 JSON이 아닌 경우 초기 데이터 설정
+      // 로컬 스토리지에 'data'가 없거나 유효한 JSON이 아닌 경우 초기 데이터 설정
       localStorage.setItem('profileData', JSON.stringify(initialData))
       setProfileData(initialData)
     }

--- a/src/pages/MyProfilePage.jsx
+++ b/src/pages/MyProfilePage.jsx
@@ -1,25 +1,13 @@
+import { useState } from 'react'
 import styled from 'styled-components'
 import Footer from '../components/organisms/Footer/Footer'
 import Header from '../components/organisms/Header/Header'
 import MyPageNav from '../components/organisms/Nav/MyPageNav'
 import DefaultProfile from '../components/templates/Profile/DefaultProfile'
-import { ProfileContext } from '../context/ProfileContext'
-import { useContext, useState } from 'react'
-import { saveData } from '../utils/saveData'
 import { MetaData } from '../utils/metaData'
 
 export default function MyProfilePage() {
   const [isReady, setIsReady] = useState(true)
-  const { profileData } = useContext(ProfileContext)
-
-  const saveProfile = (data) => {
-    if (profileData.name) {
-      saveData('profileData', JSON.stringify(data))
-      alert('프로필이 저장되었습니다.')
-    } else {
-      alert('이름을 입력해주세요.')
-    }
-  }
 
   const meta = {
     title: 'MAKE:RE',
@@ -35,13 +23,6 @@ export default function MyProfilePage() {
         <MyPageNav currentNaveItem={1} />
         <Main>
           <DefaultProfile setIsReady={setIsReady} />
-          <Button
-            isReady={isReady}
-            disabled={!isReady}
-            onClick={() => saveProfile(profileData)}
-          >
-            저장하기
-          </Button>
         </Main>
       </Cont>
       <Footer />
@@ -64,19 +45,4 @@ const Main = styled.main`
   flex-direction: column;
   gap: 40px;
   align-items: center;
-`
-
-const Button = styled.button`
-  width: 240px;
-  border-radius: 10px;
-  background-color: ${(props) =>
-    props.isReady === true ? 'var(--primary-color)' : 'var(--gray-lv2-color)'};
-  padding: 11px 0;
-  color: ${(props) =>
-    props.isReady === true
-      ? 'var(--background-color)'
-      : 'var(--gray-lv3-color)'};
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 20px;
 `


### PR DESCRIPTION
# 📝 PR: 기본 프로필 하단 저장 버튼 에러 수정

## Summary
하단 저장 버튼 클릭 시 새로 입력한 데이터 값이 저장되지 않고 기존 로컬스토리지 데이터로 초기화되는 현상 수정

## Description
`DefaultProfile` 컴포넌트 내부 버튼으로 이동 및 상단 저장 버튼의 데이터 및 함수 공유

close #302 