### PR TITLE
✨ Feat: 깃허브 아이디 입력하지 않았을 때 빈 잔디 UI 제거

### DIFF
--- a/src/components/templates/Profile/ProfilePreview.jsx
+++ b/src/components/templates/Profile/ProfilePreview.jsx
@@ -1,6 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react'
 import styled from 'styled-components'
-import { LocalContext } from '../../../pages/PreviewPage'
 import ColorContext from '../../../context/ColorContext'
 import { PreviewProfileItem } from '../../atoms/PreviewItem'
 import Spinner from '../../../assets/loader.svg'
@@ -80,20 +79,21 @@ export default function ProfilePreview() {
             title="경력 사항"
             content={currentProfileData.careerLength}
           ></PreviewProfileItem>
-          <PreviewProfileItem
-            title="깃허브 아이디"
-            content={currentProfileData.github[0]}
-          ></PreviewProfileItem>
-          {commitURL ? (
-            <img
-              src={commitURL}
-              className="commit"
-              alt="깃허브 커밋기록 이미지"
-            />
-          ) : (
-            <div className="loading">
-              <img src={Spinner} alt="" />
-            </div>
+          {githubID && (
+            <>
+              <PreviewProfileItem
+                title="깃허브 아이디"
+                content={currentProfileData.github[0]}
+              ></PreviewProfileItem>
+              <img
+                src={commitURL}
+                className="commit"
+                alt="깃허브 커밋기록 이미지"
+              />
+              {/* <div className="loading">
+                <img src={Spinner} alt="" />
+              </div> */}
+            </>
           )}
           {currentProfileData?.blog && (
             <PreviewLink


### PR DESCRIPTION
# 📝 PR: 깃허브 아이디 입력하지 않았을 때 빈 잔디 UI 제거

## Summary
- 깃허브 입력 여부를 commitURL이 아닌 githubID로 확인 
  - commitURL: 아이디를 입력하지 않았을 시에 계정명 undefined로 항시 존재
  - githubID: 아이디 입력 시 이력서 내 프로필 항목으로 저장 

## Description
- 기존 로딩 스피너는 메인 컬러 변경 시 commitURL 유무로 등장했는데, 아이디가 없을 시에도 commitURL은 존재하기에 따로 동작하지 않아 임시 주석처리해두었습니다. 

close #318 