### PR TITLE
🐛 Fix: 랜덤 포커싱 이슈 수정 (첫 번째 input에 자동 포커싱 되도록)

### DIFF
--- a/src/components/atoms/Input/DefaultInput.jsx
+++ b/src/components/atoms/Input/DefaultInput.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import { styled } from 'styled-components'
 import LinkIcon from '../../../assets/icon-Url.svg'
 
@@ -14,7 +15,16 @@ export default function DefaultInput({
   onChange,
   onKeyDown,
   maxLength,
+  isFirst,
 }) {
+  const inputRef = useRef(null)
+
+  useEffect(() => {
+    if (isFirst && inputRef.current) {
+      inputRef.current.focus()
+    }
+  }, [])
+
   return (
     <InputCont type={type}>
       <Label htmlFor={id}>
@@ -22,6 +32,7 @@ export default function DefaultInput({
         <strong> {essentialMsg}</strong>
       </Label>
       <Input
+        ref={inputRef}
         id={id}
         type={type}
         name={name}
@@ -33,7 +44,7 @@ export default function DefaultInput({
         onKeyDown={onKeyDown}
         autoComplete="off"
         maxLength={maxLength}
-        autoFocus
+        // autoFocus
       />
     </InputCont>
   )

--- a/src/components/atoms/Input/DefaultInput.jsx
+++ b/src/components/atoms/Input/DefaultInput.jsx
@@ -44,7 +44,6 @@ export default function DefaultInput({
         onKeyDown={onKeyDown}
         autoComplete="off"
         maxLength={maxLength}
-        // autoFocus
       />
     </InputCont>
   )

--- a/src/components/atoms/Input/RequireInput.jsx
+++ b/src/components/atoms/Input/RequireInput.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useRef, useContext, useEffect } from 'react'
 import styled from 'styled-components'
 import AlertIcon from '../../../assets/icon-alert-circle.svg'
 import ColorIcon from '../ColorIcon/ColorIcon'
@@ -32,12 +32,20 @@ export default function RequireInput({
   width,
 }) {
   const { formRef } = useContext(ResumeContext)
+  const inputRef = useRef(null)
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus()
+    }
+  }, [])
 
   return (
     <Form id="requiredForm" ref={formRef} width={width}>
       <div type={type} className="inputWrap">
         <label htmlFor={id}>{children}</label>
         <input
+          ref={inputRef}
           id={id}
           type={type}
           name={name}

--- a/src/components/organisms/Component/Certificate.jsx
+++ b/src/components/organisms/Component/Certificate.jsx
@@ -32,6 +32,7 @@ export default function Certificate({
           onChange={(e) => updateData(e, idx, certData, setCertData)}
           inputData={cert.title}
           maxLength={45}
+          isFirst={true}
         >
           자격증명
         </DefaultInput>

--- a/src/components/organisms/Component/Education.jsx
+++ b/src/components/organisms/Component/Education.jsx
@@ -37,6 +37,7 @@ export default function Education({
           }}
           inputData={edu.title}
           maxLength={45}
+          isFirst={true}
         >
           교육명
         </DefaultInput>

--- a/src/components/organisms/Component/Experience.jsx
+++ b/src/components/organisms/Component/Experience.jsx
@@ -40,6 +40,7 @@ export default function Experience({
               updateData(e, idx, expData, setExpData)
             }}
             maxLength={45}
+            isFirst={true}
           >
             경험명
           </DefaultInput>

--- a/src/components/organisms/Component/Url.jsx
+++ b/src/components/organisms/Component/Url.jsx
@@ -36,6 +36,7 @@ export default function Url({
               updateData(e, idx, urlData, setUrlData)
             }}
             maxLength={45}
+            isFirst={true}
           >
             URL 이름 또는 설명
           </DefaultInput>


### PR DESCRIPTION
# 📝 PR: 각 페이지 별 첫 번째 input에 자동 포커싱

## Summary
- `DefaultInput` 컴포넌트의 `autofocus` 속성으로 인해 각 페이지의 마지막 `DefaultInput`에 포커싱되는 이슈 발생
- 사용자 편의를 위해 첫 번째 input에 자동 포커싱될 필요가 있어 아래와 같이 수정했습니다.
- 수정 대상 컴포넌트: `DefaultInput`, `RequireInput`

## Description
- 공통적으로 `useRef`를 사용하나, 추가적인 `props` 전달에 차이가 있습니다
  - `DefaultInput`: 사용되는 곳이 많으므로 첫 번째 요소 여부 확인을 위한 `isFirst props` 전달
  - `RequireInput` (이름, 회사명, 프로젝트명): 항시 각 섹션의 첫 번째 항목이므로 useRef만 사용


close #319