### PR TITLE
✨ Feat: ResumeStore 내 최종 수정일 로직 추가

### DIFF
--- a/src/store/ResumeStore.jsx
+++ b/src/store/ResumeStore.jsx
@@ -24,6 +24,7 @@ export const useResumeStore = create(
               id: val.id,
               content: val.content,
               name: '새로운 이력서',
+              lastModified: getCurrentDate(),
             },
           ],
         })),
@@ -36,7 +37,9 @@ export const useResumeStore = create(
       updateResumeName: (id, name) =>
         set((prev) => ({
           resumeList: prev.resumeList.map((el) =>
-            el.id === id ? { ...el, name: name } : el
+            el.id === id
+              ? { ...el, name: name, lastModified: getCurrentDate() }
+              : el
           ),
         })),
       // 이력서 내부 정보 수정
@@ -44,7 +47,11 @@ export const useResumeStore = create(
         set((prev) => ({
           resumeList: prev.resumeList.map((el) =>
             el.id === parseInt(id)
-              ? { ...el, content: { ...el.content, [key]: value } }
+              ? {
+                  ...el,
+                  content: { ...el.content, [key]: value },
+                  lastModified: getCurrentDate(),
+                }
               : el
           ),
         })),
@@ -62,6 +69,7 @@ export const useResumeStore = create(
                       [key]: value,
                     },
                   },
+                  lastModified: getCurrentDate(),
                 }
               : el
           ),


### PR DESCRIPTION
# 📝 PR: ResumeStore 내 최종 수정일 로직 추가

## Description
상태 관리 로직을 변경하며 `ResumeStore` 내에 최종 수정일 로직이 누락되어 새로운 이력서 생성 시 `lastModified` 속성이 추가되어 있지 않는 등 해당 기능이 동작하지 않는 이슈가 있어 다음과 같은 시점에 `getCurrentDate` 함수가 동작하도록 수정했습니다.
- 새로운 이력서 생성 시 
- 이력서 타이틀 수정 시
- 이력서 세부 내용 수정 시
- 이력서 내 프로필 데이터 수정 시


